### PR TITLE
Fix memory leak caused by fragments not being destroyed

### DIFF
--- a/packages/model-fragments/lib/fragments/array/fragment.js
+++ b/packages/model-fragments/lib/fragments/array/fragment.js
@@ -234,6 +234,20 @@ var FragmentArray = StatefulArray.extend({
     var fragment = store.createFragment(type, props);
 
     return this.pushObject(fragment);
+  },
+
+  willDestroy: function() {
+    this._super.apply(this, arguments);
+
+    // destroy the current state
+    this.forEach(function(fragment) {
+      fragment.destroy();
+    });
+
+    // destroy the original state
+    this._originalState.forEach(function(fragment) {
+      fragment.destroy();
+    });
   }
 });
 

--- a/packages/model-fragments/lib/fragments/ext.js
+++ b/packages/model-fragments/lib/fragments/ext.js
@@ -7,6 +7,7 @@ import {
   internalModelFor,
   default as Fragment
 } from './fragment';
+import FragmentArray from './array/fragment';
 
 /**
   @module ember-data-model-fragments
@@ -151,6 +152,29 @@ Model.reopen({
 
     return diffData;
   },
+
+  willDestroy: function() {
+    this._super.apply(this, arguments);
+
+    var internalModel = internalModelFor(this);
+    var key, fragment;
+
+    // destroy the current state
+    for (key in internalModel._fragments) {
+      if (fragment = internalModel._fragments[key]) {
+        fragment.destroy();
+      }
+    }
+
+    // destroy the original state
+    for (key in internalModel._data) {
+      if (fragment = internalModel._data[key]) {
+        if (fragment instanceof Fragment || fragment instanceof FragmentArray) {
+          fragment.destroy();
+        }
+      }
+    }
+  }
 });
 
 // Replace a method on an object with a new one that calls the original and then

--- a/packages/model-fragments/tests/integration/nested_test.js
+++ b/packages/model-fragments/tests/integration/nested_test.js
@@ -251,3 +251,51 @@ test("Nested fragments can be copied", function() {
     ok(product !== user.get('orders.firstObject.product'), 'nested fragment copies are new fragments');
   });
 });
+
+test("Nested fragments are destroyed when the owner record is destroyed", function() {
+  store.push({
+    data: {
+      type: 'user',
+      id: 1,
+      attributes: {
+        info: {
+          name: 'Tyrion Lannister',
+          notes: [ 'smart', 'short' ]
+        },
+        orders: [
+          {
+            amount: '10999.99',
+            products: [
+              {
+                name  : 'Lives of Four Kings',
+                sku   : 'old-book-32',
+                price : '10999.99'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  });
+
+  return store.find('user', 1).then(function(user) {
+    var info = user.get('info');
+    var notes = info.get('notes');
+    var orders = user.get('orders');
+    var order = orders.get('firstObject');
+    var products = order.get('products');
+    var product = products.get('firstObject');
+
+    user.destroy();
+
+    Ember.run.schedule('destroy', function() {
+      ok(user.get('isDestroying'), "the user is being destroyed");
+      ok(info.get('isDestroying'), "the info is being destroyed");
+      ok(notes.get('isDestroying'), "the notes are being destroyed");
+      ok(orders.get('isDestroying'), "the orders are being destroyed");
+      ok(order.get('isDestroying'), "the order is being destroyed");
+      ok(products.get('isDestroying'), "the products are being destroyed");
+      ok(product.get('isDestroying'), "the product is being destroyed");
+    });
+  });
+});

--- a/packages/model-fragments/tests/unit/fragment_array_property_test.js
+++ b/packages/model-fragments/tests/unit/fragment_array_property_test.js
@@ -401,3 +401,43 @@ test("fragment default values can be functions", function() {
     equal(sword.get('addresses.firstObject.street'), defaultValue[0].street, "the default value is correct");
   });
 });
+
+test("destroy a fragment array which was set to null", function() {
+  pushPerson(1);
+
+  return store.find('person', 1).then(function(person) {
+    var addresses = person.get('addresses');
+    var firstAddress = addresses.objectAt(0);
+    var secondAddress = addresses.objectAt(1);
+    person.set('addresses', null);
+
+    person.destroy();
+
+    Ember.run.schedule('destroy', function() {
+      ok(person.get('isDestroying'), "the model is being destroyed");
+      ok(addresses.get('isDestroying'), "the fragment array is being destroyed");
+      ok(firstAddress.get('isDestroying'), "the first fragment is being destroyed");
+      ok(secondAddress.get('isDestroying'), "the second fragment is being destroyed");
+    });
+  });
+});
+
+test("destroy a fragment which was removed from the fragment array", function() {
+  pushPerson(1);
+
+  return store.find('person', 1).then(function(person) {
+    var addresses = person.get('addresses');
+    var firstAddress = addresses.objectAt(0);
+    var secondAddress = addresses.objectAt(1);
+    addresses.removeAt(0);
+
+    person.destroy();
+
+    Ember.run.schedule('destroy', function() {
+      ok(person.get('isDestroying'), "the model is being destroyed");
+      ok(addresses.get('isDestroying'), "the fragment array is being destroyed");
+      ok(firstAddress.get('isDestroying'), "the removed fragment is being destroyed");
+      ok(secondAddress.get('isDestroying'), "the remaining fragment is being destroyed");
+    });
+  });
+});

--- a/packages/model-fragments/tests/unit/fragment_property_test.js
+++ b/packages/model-fragments/tests/unit/fragment_property_test.js
@@ -269,3 +269,61 @@ test("fragment default values can be functions", function() {
     equal(sword.get('name.first'), defaultValue.first, "the default value is correct");
   });
 });
+
+test("destroy a fragment which was set to null", function() {
+  store.push({
+    data: {
+      type: 'person',
+      id: 1,
+      attributes: {
+        name: {
+          first: "Barristan",
+          last: "Selmy"
+        }
+      }
+    }
+  });
+
+  return store.find('person', 1).then(function(person) {
+    var name = person.get('name');
+    person.set('name', null);
+
+    person.destroy();
+
+    Ember.run.schedule('destroy', function() {
+      ok(person.get('isDestroying'), "the model is being destroyed");
+      ok(name.get('isDestroying'), "the fragment is being destroyed");
+    });
+  });
+});
+
+test("destroy the old and new fragment value", function() {
+  store.push({
+    data: {
+      type: 'person',
+      id: 1,
+      attributes: {
+        name: {
+          first: "Barristan",
+          last: "Selmy"
+        }
+      }
+    }
+  });
+
+  return store.find('person', 1).then(function(person) {
+    var oldName = person.get('name');
+    var newName = store.createFragment('name');
+    person.set('name', newName);
+
+    ok(!oldName.get('isDestroying'), "don't destroy the old fragment yet because we could rollback");
+
+    person.destroy();
+
+    Ember.run.schedule('destroy', function() {
+      ok(person.get('isDestroying'), "the model is being destroyed");
+      ok(oldName.get('isDestroying'), "the old fragment is being destroyed");
+      ok(newName.get('isDestroying'), "the new fragment is being destroyed");
+    });
+  });
+});

--- a/packages/model-fragments/tests/unit/fragment_test.js
+++ b/packages/model-fragments/tests/unit/fragment_test.js
@@ -193,3 +193,11 @@ test("changes to attributes can be rolled back", function() {
     ok(!name.get('hasDirtyAttributes'), "fragment is in clean state");
   });
 });
+
+test("fragments without an owner can be destroyed", function() {
+  Ember.run(function() {
+    var fragment = store.createFragment('name');
+    fragment.destroy();
+    ok(fragment.get('isDestroying'), "the fragment is being destroyed");
+  });
+});

--- a/packages/model-fragments/tests/unit/store_test.js
+++ b/packages/model-fragments/tests/unit/store_test.js
@@ -72,3 +72,22 @@ test("the application serializer can be looked up", function() {
 test("the default serializer can be looked up", function() {
   ok(store.serializerFor('-default') instanceof DS.JSONSerializer, "default serializer can still be looked up");
 });
+
+test("unloadAll destroys fragments", function() {
+  Ember.run(function() {
+    var person = store.createRecord('person', {
+      name: {
+        first: "Catelyn",
+        last: "Stark"
+      }
+    });
+    var name = person.get('name');
+
+    store.unloadAll();
+
+    Ember.run.schedule('destroy', function() {
+      ok(person.get('isDestroying'), "the model is being destroyed");
+      ok(name.get('isDestroying'), "the fragment is being destroyed");
+    });
+  });
+});


### PR DESCRIPTION
I tracked down a memory leak since my acceptance tests started running the process out of memory. This is from a heap snapshot showing the ember `Container` instance being rooted in `window`:

```
container in Class @8620175
 _object in ChainNode @8620223
  _parent in ChainNode @8614719
   [2] in Array @8610299
    isDirty in EmptyObject @8607285
     chains in ChainWatchers @8601471
      _chainWatchers in Meta @8065411
       __ember_meta__ in @7311237
        saved in @8042657
         loaded in @8042653
          model$fragments$lib$fragments$states$$default in system / Context @8042649
           context in model$fragments$lib$fragments$attributes$$fragmentArray() @8042947
            fragmentArray in Class @7447369
             MF in Window
```
I had about as many containers rooted as the number of acceptance tests.

The leak happens because `window.MF` has the `FragmentRootState`. Calling e.g. `fragment.get('isDirty')` registers a watcher on `currentState` which is the rooted state object. `fragment.destroy` never gets called to clean up the watcher.

When you call `application.destroy` or `store.unloadAll`, ember-data goes through its registry and destroys each model instance. There's no such registry for fragments so they hang around forever.

The pull request changes `DS.Model#destroy` to recursively destroy any fragments which the model owns. Ownership is tracked by a new property `_owns` (which is the inverse of `_owner`).

With this fix applied, chrome's `performance.memory.usedJSHeapSize` after running my test suite improves from 624 MB (at edmf master branch) to 239 MB.

Also fixes #106