### PR TITLE
Fixing #177. Ensures that adapter errors are properly handled.

### DIFF
--- a/packages/model-fragments/lib/fragments/array/fragment.js
+++ b/packages/model-fragments/lib/fragments/array/fragment.js
@@ -130,6 +130,20 @@ var FragmentArray = StatefulArray.extend({
   },
 
   /**
+    @method _adapterDidError
+    @private
+  */
+  _adapterDidError: function(error) {
+    this._super(error);
+
+    // Notify all records of the error; if the adapter update did not contain new
+    // data, just notify each fragment so it can transition to a clean state
+    this.forEach(function(fragment) {
+      fragment._adapterDidError(error);
+    });
+  },
+
+  /**
     If this property is `true`, either the contents of the array do not match
     its original state, or one or more of the fragments in the array are dirty.
 

--- a/packages/model-fragments/lib/fragments/array/stateful.js
+++ b/packages/model-fragments/lib/fragments/array/stateful.js
@@ -119,6 +119,10 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     }
   },
 
+  _adapterDidError: function(/*error*/) {
+    // No-Op
+  },
+
   /**
     If this property is `true` the contents of the array do not match its
     original state. The array has local changes that have not yet been saved by

--- a/packages/model-fragments/lib/fragments/ext.js
+++ b/packages/model-fragments/lib/fragments/ext.js
@@ -274,6 +274,18 @@ decorateMethod(InternalModelPrototype, 'adapterDidCommit', function adapterDidCo
   }
 });
 
+decorateMethod(InternalModelPrototype, 'adapterDidError', function adapterDidErrorFragments(returnValue, args) {
+  var error = args[0] || create(null);
+  var fragment;
+
+  // Notify fragments that the record was committed
+  for (var key in this._fragments) {
+    if (fragment = this._fragments[key]) {
+      fragment._adapterDidError(error);
+    }
+  }
+});
+
 /**
   @class JSONSerializer
   @namespace DS

--- a/packages/model-fragments/lib/fragments/fragment.js
+++ b/packages/model-fragments/lib/fragments/fragment.js
@@ -118,6 +118,13 @@ var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
     });
   },
 
+  /**
+    @method _adapterDidCommit
+  */
+  _adapterDidError: function(/*error*/) {
+    internalModelFor(this)._saveWasRejected();
+  },
+
   toStringExtension: function() {
     return 'owner(' + get(internalModelFor(this)._owner, 'id') + ')';
   }

--- a/packages/model-fragments/tests/integration/save_test.js
+++ b/packages/model-fragments/tests/integration/save_test.js
@@ -1,4 +1,4 @@
-var env, store, Person, Name, Address, Hobby;
+var env, store, Person, Name, Address, Hobby, Army;
 
 QUnit.module("integration - Persistence", {
   setup: function() {
@@ -24,11 +24,17 @@ QUnit.module("integration - Persistence", {
       name: DS.attr('string')
     });
 
+    Army = DS.Model.extend({
+      name     : DS.attr('string'),
+      soldiers : MF.array()
+    });
+
     env = setupEnv({
       person: Person,
       name: Name,
       address: Address,
-      hobby: Hobby
+      hobby: Hobby,
+      army: Army
     });
 
     store = env.store;
@@ -43,6 +49,7 @@ QUnit.module("integration - Persistence", {
     Person = null;
     Address = null;
     Hobby = null;
+    Army = null;
   }
 });
 
@@ -488,13 +495,6 @@ test("fragment array properties are notifed on reload", function() {
   // The extra assertion comes from deprecation checking
   expect(2);
 
-  var Army = DS.Model.extend({
-    name     : DS.attr('string'),
-    soldiers : MF.array()
-  });
-
-  env.registry.register('model:army', Army);
-
   var data = {
     name: "Golden Company",
     soldiers: [
@@ -531,5 +531,97 @@ test("fragment array properties are notifed on reload", function() {
   return store.find('army', 1).then(function(army) {
     ArmyObserver.create({ army: army });
     return army.reload();
+  });
+});
+
+test('string array can be rolled back on failed save', function() {
+  expect(3);
+
+  var data = {
+    name: "Golden Company",
+    soldiers: [
+      "Aegor Rivers",
+      "Jon Connington",
+      "Tristan Rivers"
+    ]
+  };
+
+  store.push({
+    data: {
+      type: 'army',
+      id: 1,
+      attributes: data
+    }
+  });
+
+  env.adapter.updateRecord = function() {
+    return Ember.RSVP.reject({});
+  };
+
+  var army, soliders;
+  return store.find('army', 1).then(function(_army) {
+    army = _army;
+    soliders = army.get('soldiers');
+    soliders.pushObject('Lysono Maar');
+    soliders.removeObject('Jon Connington');
+
+    deepEqual(soliders.toArray(), ['Aegor Rivers', 'Tristan Rivers', 'Lysono Maar']);
+
+    return army.save();
+  }).catch(function() {
+    army.rollbackAttributes();
+
+    deepEqual(soliders.toArray(), ['Aegor Rivers', 'Jon Connington', 'Tristan Rivers']);
+  });
+});
+
+test('existing fragments can be rolled back on failed save', function() {
+  expect(3);
+
+  var data = {
+    name: {
+      first: 'Eddard',
+      last: 'Stark'
+    },
+    addresses: [
+      {
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
+      }
+    ]
+  };
+
+  store.push({
+    data: {
+      type: 'person',
+      id: 1,
+      attributes: data
+    }
+  });
+
+  env.adapter.updateRecord = function() {
+    return Ember.RSVP.reject({});
+  };
+
+  var mrStark, name, address;
+
+  return store.find('person', 1).then(function(person) {
+    mrStark = person;
+
+    name = mrStark.get('name');
+    address = mrStark.get('addresses.firstObject');
+
+    name.set('first', 'BadFirstName');
+    name.set('last', 'BadLastName');
+    address.set('street', 'BadStreet');
+
+    return mrStark.save();
+  }).catch(function() {
+    mrStark.rollbackAttributes();
+
+    equal(name.get('first') + ' ' + name.get('last'), 'Eddard Stark', 'fragment name rolled back');
+    equal(address.get('street'), '1 Great Keep', 'fragment array fragment correctly rolled back');
   });
 });


### PR DESCRIPTION
This PR is intended to fix #177. It ensures adapter errors are properly handled.

There are some open questions here and I would like @slindberg to weigh in when he is able to. 

One question is should the fragments call `internalModelFor(this)._saveWasRejected()` instead of `    internalModelFor(this).adapterDidError(error);`? The challenge I discovered was that the internal-model's [adapterDidError](https://github.com/emberjs/data/blob/266ae624a6005092f7e3758005920039081b8884/addon/-private/system/model/internal-model.js#L735-L743) ultimately tries to call `this.send('becameError');`. However since the fragment never enters the inFlight state, that `becomeError` isn't a valid action. 

Second question, what does it mean for a fragment to be in "error"? I passed the error object for the model through all the fragment hooks so it would be available, but they really don't consume them. If we wanted fragments to consume and reflect the error it would create more questions. For example, "how should a fragment use an error?", "What the format of that error would be?", etc, etc, etc. 

I spent several hours thinking about this. I feel like this is the most pragmatic solution. While it has it's shortcomings, it does fix the bug and restore what I would say is expected functionality. 