### PR TITLE
Fixed issue with 'isNew' for newly created fragments

### DIFF
--- a/packages/model-fragments/lib/fragments/states.js
+++ b/packages/model-fragments/lib/fragments/states.js
@@ -107,6 +107,8 @@ var FragmentRootState = {
     created: {
       isDirty: true,
 
+      isNew: true,
+
       setup: dirtySetup,
 
       didCommit: function(internalModel) {

--- a/packages/model-fragments/tests/integration/save_test.js
+++ b/packages/model-fragments/tests/integration/save_test.js
@@ -46,6 +46,31 @@ QUnit.module("integration - Persistence", {
   }
 });
 
+test("persisting the owner record changes the fragment state to non-new", function() {
+  var data = {
+    name: {
+      first: "Viserys",
+      last: "Targaryen"
+    }
+  };
+
+  var person = store.createRecord('person');
+
+  person.set('name', store.createFragment('name', data.name));
+
+  env.adapter.createRecord = function() {
+    var payload = Ember.copy(data, true);
+
+    payload.id = 3;
+
+    return Ember.RSVP.resolve(payload);
+  };
+
+  return person.save().then(function(person) {
+    ok(!person.get('name.isNew'), "fragments are not new after save");
+  });
+});
+
 test("persisting the owner record in a clean state maintains clean state", function() {
   store.push({
     data: {

--- a/packages/model-fragments/tests/unit/fragment_test.js
+++ b/packages/model-fragments/tests/unit/fragment_test.js
@@ -125,6 +125,14 @@ test("fragments are compared by reference", function() {
   });
 });
 
+test("newly create fragments start in the new state", function() {
+  Ember.run(function() {
+    var fragment = store.createFragment('name');
+
+    ok(fragment.get('isNew'), "fragments start as new");
+  });
+});
+
 test("changes to fragments are indicated in the owner record's `changedAttributes`", function() {
   store.push({
     data: {


### PR DESCRIPTION
Fixes #159 

@workmanw I'm thinking I just left this out when initially creating the state machine, but I wanted a gut check from you. There's no deleted state for a fragment, but there is a new state, and I don't think there's any harm in reporting it as 'isNew'.