### PR TITLE
Lock ember-data to supported version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "ember": "^2.2.0",
-    "ember-data": "^2.2.0"
+    "ember-data": "~2.2.0"
   },
   "devDependencies": {
     "jquery": "^2.0.0",


### PR DESCRIPTION
With the current version strategy in bower.json, this addon will install 2.4.1 and therefore tests will fail in master.

Now it will stay in 2.2.X.
