### PR TITLE
First pass at updating the README.md to match the new addonify patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,9 +426,9 @@ import attr from 'ember-data/attr';
 import { fragmentArray } from 'model-fragments/attributes';
 
 export default Model.extend({
-  name: attr("string"),
-  city: attr("string"),
-  animals: fragmentArray("animal", { polymorphic: true, typeKey: '$type' }),
+  name: attr('string'),
+  city: attr('string'),
+  animals: fragmentArray('animal', { polymorphic: true, typeKey: '$type' }),
 });
 ```
 
@@ -438,27 +438,27 @@ import Fragment from 'model-fragments/fragment';
 import attr from 'ember-data/attr';
 
 App.Animal = Fragment.extend({
-  name: attr("string"),
+  name: attr('string'),
 });
 ```
 
 ```javascript
 // app/models/elephant.js
-import Animal from "./Animal";
+import Animal from './Animal';
 import attr from 'ember-data/attr';
 
 export default Animal.extend({
-  trunkLength: attr("number"),
+  trunkLength: attr('number'),
 });
 ```
 
 ```javascript
 // app/models/lion.js
-import Animal from "./Animal";
+import Animal from './Animal';
 import attr from 'ember-data/attr';
 
 export default Animal.extend({
-  hasManes: attr("boolean"),
+  hasManes: attr('boolean'),
 });
 ```
 
@@ -518,7 +518,7 @@ export default JSONSerializer.extend({
 });
 ```
 
-```javscript
+```javascript
 // app/serializers/elephant.js
 import AnimalSerializer from './animal';
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use the following table to decide which version of this project to use with your
 | >= v1.0.0-beta.15 <= v1.0.0-beta.18 | v0.3.3 |
 | >= v1.13.x < v2.0.0 | v1.13.x |
 | >= v2.0.x < v2.1.0 | v2.0.x |
-| >= v2.1.x | v2.1.x |
+| >= v2.1.x < v2.3.x | v2.1.x |
 | >= v2.3.x | v2.3.x |
 
 #### Notes
@@ -29,7 +29,7 @@ Use the following table to decide which version of this project to use with your
 - Ember Data v1.0.0-beta.12 introduced a bug that makes it incompatible with any version of this project.
 - Ember Data v1.0.0-beta.15 introduced a breaking change to the serializer API with [Snapshots](https://github.com/emberjs/data/pull/2623). Since this affected fragment serialization as well, support for it was added in v0.3.0. See the [serializing](#serializing) section below for more information.
 - Ember Data v1.0.0-beta.19 refactored a large number of internal APIs this project relied on and is not officially supported. Compatibility was added in v0.4.0 and targeted at Ember Data v1.13.x.
-- Ember Data 2.3 converted to a full Ember CLI addon. Removing the global `DS` namespace and switching to an import module strategy. More: [Ember Data 2.3 Released](http://emberjs.com/blog/2016/01/12/ember-data-2-3-released.html).  
+- Ember Data 2.3 converted to a full Ember CLI addon. Removing the global `DS` namespace and switching to an import module strategy. More: [Ember Data 2.3 Released](http://emberjs.com/blog/2016/01/12/ember-data-2-3-released.html). Following ember-data's lead, the `MF` namespace was also removed. Import modules directly.
 
 ## Installation
 
@@ -553,20 +553,25 @@ Currently, fragments cannot have normal `belongsTo` or `hasMany` relationships. 
 Building requires [Ember CLI](http://www.ember-cli.com/) and running tests requires [Test 'Em](https://github.com/airportyh/testem), which can all be installed globally with:
 
 ```sh
-$ npm install --global ember-cli testem
+$ npm install --global ember-cli
 ```
 
-Then install NPM packages, build the project, and start the development test server:
+Then install NPM packages and start the development test server:
 
 ```sh
 $ npm install
-$ ember build
-$ testem
+$ ember test --server
 ```
 
-If you encounter test errors, ensure that your global testem NPM package is up to date.
+It is also possible to run the tests in a headless fashion. This requires [PhantomJS 2](http://phantomjs.org) to be installed.
 
-When developing, it is often convenient to build the project with `ember serve` which will watch for file changes and rebuild, which triggers the test runner to re-run tests. 
+```sh
+$ ember test
+
+# Using `npm test` will invoke `ember try:testall`.
+# This will test each version of ember supported by this addon.
+$ npm test
+```
 
 ## Contributing
 


### PR DESCRIPTION
I'm submitting this as a PR to the addonify branch so that @slindberg and @jakesjews can review it. Here is a link to the [rendered view](https://github.com/workmanw/ember-data-model-fragments/blob/d15613cf9d62c30e604dc08d5031adeddc7e975a/README.md).

There are two things I specifically wanted to get feedback on. 

1. Since I've upgraded the docs to use the newish ES6 model pattern (rather than globals) the examples tend to have more files. See [here](https://github.com/workmanw/ember-data-model-fragments/blob/d15613cf9d62c30e604dc08d5031adeddc7e975a/README.md#example). I added the name of the model as a path based code comment at the top of each snippet. This is what many addons do, include the official ember model guides. My question is, is that clear enough for someone reading it? If not, I think a good alternative would be to make a variable, we do this in our app. Eg.

    ```javascript
    // app/models/person.js
    import Model from 'ember-data/model';
    import {
      fragment,
      fragmentArray,
      array
    } from 'model-fragments/attributes';

    let PersonModel = Model.extend({
      name      : fragment('name'),
      addresses : fragmentArray('address'),
      titles    : array()
    });

    export default PersonModel;
    ```

2. `fragment` and `Fragment` look kind of ambiguous in the documentation. If you didn't catch the difference, the former is the attribute marco while the later is the model class. Just looking at it, it seems ripe for confusion. Perhaps I should change `fragment` to `fragmentAttr`? But then what about `fragmentArray` and `array`, would you call them `fragmentArrayAttr` and `arrayAttr` respectfully? Thoughts?

TODO:
- [x] We probably don't need to meantion `ember build` any more.
- [x] Document how to use `testem` and `ember try:testall`.