### PR TITLE
ember 2.5 compatibility

### DIFF
--- a/addon/fragment.js
+++ b/addon/fragment.js
@@ -126,7 +126,12 @@ var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
   },
 
   toStringExtension: function() {
-    return 'owner(' + get(internalModelFor(this)._owner, 'id') + ')';
+    let owner = internalModelFor(this)._owner;
+    if (owner) {
+      return 'owner(' + get(owner, 'id') + ')';
+    } else {
+      return '';
+    }
   }
 }).reopenClass({
   fragmentOwnerProperties: Ember.computed(function() {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-data-model-fragments",
   "devDependencies": {
-    "ember": "~2.4.3",
+    "ember": "~2.5.0",
     "ember-cli-shims": "0.1.1",
     "pretender": "^1.0.0",
     "ember-cli-test-loader": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-cli": "2.4.2",
+    "ember-cli": "2.4.3",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-inject-live-reload": "^1.3.1",

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,9 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let assign = Ember.assign || Ember.merge;
+  let attributes = assign({}, config.APP);
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Replace deprecated use of Ember.merge with Ember.assign.

Right now an assertion is being triggered in ember-data since Ember.merge is being used and this is causing a null exception in toString() since it's called before the owner is set. It seems like there could be other cases where toString could be called before a parent is assigned so this might be a useful fix.