### PR TITLE
updates polymorphisme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ import Fragment from 'model-fragments/fragment';
 import attr from 'ember-data/attr';
 
 App.Animal = Fragment.extend({
-  $type: attr('string),
+  $type: attr('string'),
   name: attr('string'),
 });
 ```

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ However, note that fragments do not currently support `belongsTo` or `hasMany` p
 Ember Data: Model Fragments has support for *reading* polymorphic fragments. To use this feature, pass an options object to `fragment` or `fragmentArray`
 with `polymorphic` set to true. In addition the `typeKey` can be set, which defaults to `'type'`.
 
-The `typeKey`'s value must be the lowercase name of a class that is assignment-compatible to the declared type of the fragment attribute. That is, it must be the declared type itself or a subclass.
+The `typeKey`'s value must be the lowercase name of a class that is assignment-compatible to the declared type of the fragment attribute. That is, it must be the declared type itself or a subclass. Additionally, the `typeKey`'s value must be a field on the parent class.
 
 In the following example the declared type of `animals` is `animal`, which corresponds to the class `App.Animal`. `App.Animal` has two subclasses: `App.Elephant` and `App.Lion`,
 so to `typeKey`'s value can be `'animal'`, `'elephant'` or `'lion'`.
@@ -467,6 +467,7 @@ import Fragment from 'model-fragments/fragment';
 import attr from 'ember-data/attr';
 
 App.Animal = Fragment.extend({
+  $type: attr('string),
   name: attr('string'),
 });
 ```


### PR DESCRIPTION
The example did not work for me without this patch. (tried with Ember(Data) 2.7 and 2.8).

Perhaps I did it [incorrect](https://github.com/lytics/ember-data-model-fragments/issues/213) but I found that the following method could never work as the `data` argument did not contain the typeKey's field.

https://github.com/lytics/ember-data-model-fragments/blob/master/addon/fragment.js#L160

```
export function getActualFragmentType(declaredType, options, data) {
  console.log(declaredType, options, data); // would log: normalize Object {name: "Leonard", hasManes: true}
  if (!options.polymorphic || !data) {
    return declaredType;
  }

  var typeKey = options.typeKey || 'type';
  var actualType = data[typeKey];

  return actualType || declaredType;
}
```