### PR TITLE
Use the `ember-data` initializer as a target instead of the soon to b…

### DIFF
--- a/app/initializers/model-fragments.js
+++ b/app/initializers/model-fragments.js
@@ -7,7 +7,7 @@ import ArrayTransform from 'model-fragments/transforms/array';
 
 export default {
   name: "fragmentTransform",
-  before: "store",
+  before: "ember-data",
 
   initialize: function(application) {
     application.register('transform:fragment', FragmentTransform);


### PR DESCRIPTION
…e deprecated `store` initializer

Hello, The `store` initializer target currently is a [empty initializer](https://github.com/emberjs/data/blob/master/app/initializers/store.js#L10-L14) in Ember Data. I have an [RFC](https://github.com/emberjs/rfcs/pull/181) and a [PR](https://github.com/emberjs/data/pull/4657) to deprecate it a future Ember Data release. I did a search and found your addon is using the `store` initializer  target and I have opened this pr for you to use the `'ember-data'` initializer instead which will continue to be supported after the empty initializers are deprecated.