### PR TITLE
[WIP] Adding support for ember-data 2.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ cache:
     - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-2-11
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Use the following table to decide which version of this project to use with your
 | >= v1.13.x < v2.0.0 | v1.13.x |
 | >= v2.0.x < v2.1.0 | v2.0.x |
 | >= v2.1.x < v2.3.x | v2.1.x |
-| >= v2.3.x | v2.3.x |
+| >= v2.3.x < v2.11.x | v2.3.x |
+| >= v2.11.x | v2.11.x |
 
 #### Notes
 
@@ -30,6 +31,7 @@ Use the following table to decide which version of this project to use with your
 - Ember Data v1.0.0-beta.15 introduced a breaking change to the serializer API with [Snapshots](https://github.com/emberjs/data/pull/2623). Since this affected fragment serialization as well, support for it was added in v0.3.0. See the [serializing](#serializing) section below for more information.
 - Ember Data v1.0.0-beta.19 refactored a large number of internal APIs this project relied on and is not officially supported. Compatibility was added in v0.4.0 and targeted at Ember Data v1.13.x.
 - Ember Data 2.3 converted to a full Ember CLI addon. Removing the global `DS` namespace and switching to an import module strategy. More: [Ember Data 2.3 Released](http://emberjs.com/blog/2016/01/12/ember-data-2-3-released.html). Following ember-data's lead, the `MF` namespace was also removed. Import modules directly.
+- Ember Data 2.11 changed the implementation of their `ContainerInstanceCache`. We had to follow suite with our patches so that we could continue offering fragments their own default serializer. See [#224](https://github.com/lytics/ember-data-model-fragments/issues/224).
 
 ## Installation
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-data-model-fragments",
   "devDependencies": {
-    "ember": "~2.10.0",
+    "ember": "~2.11.0-beta.4",
     "ember-cli-shims": "0.1.3",
     "pretender": "^1.0.0"
   }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
-module.exports = {
+module.exports = function() {
+  return {
   scenarios: [
     {
       name: 'default',
@@ -12,41 +13,21 @@ module.exports = {
     },
 
     {
-      name: 'ember-lts-2.4',
+      name: 'ember-2-11',
       bower: {
         devDependencies: {
-          'ember': 'components/ember#lts-2-4'
+          'ember': '~2.11.0-beta.4',
         },
         resolutions: {
-          'ember': 'lts-2-4'
+          'ember': '~2.11.0-beta.4',
         }
       },
       npm: {
         devDependencies: {
-          'ember-data': '2.4.3'
+          'ember-data': '~2.11.0'
         },
         resolutions: {
-          'ember-data': '2.4.3'
-        }
-      }
-    },
-
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-8'
-        },
-        resolutions: {
-          'ember': 'lts-2-8'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-data': '2.8.1'
-        },
-        resolutions: {
-          'ember-data': '2.8.1'
+          'ember-data': '~2.11.0'
         }
       }
     },
@@ -91,5 +72,5 @@ module.exports = {
         }
       }
     }
-  ]
+  ]};
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-data-model-fragments",
   "description": "Ember Data addon to support nested JSON documents",
-  "version": "2.3.3",
+  "version": "2.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/lytics/ember-data-model-fragments.git"
@@ -38,7 +38,7 @@
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.10.0",
+    "ember-data": "~2.11.0",
     "ember-dev": "emberjs/ember-dev",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-load-initializers": "^0.5.1",


### PR DESCRIPTION
Adding support for Ember-Data 2.11. Fixing #224. Unfortunately this change is not going to be backwards compatible with `>= ember-data v2-10.x`.

**This is still WIP. DO NOT MERGE** 😄. My plan is to merge this after Ember-Data 2.11.0 ships.

------------

Just leaving some notes here so I can remember in 4-5 weeks 😜 .
TODOs -- Once Ember-Data `2.11.0` ships:

- [x] Restore the `ember-release` scenario in `.travis.yml`.
- [x] Update package.json to use Ember-Data-2.11 as default.
- [ ] Update CHANGELOG.md
  - [ ] Mention @runspired as co-author of solution.
  - [ ] Mention GavinJoyce for `store.isFragment` (c6834f8)
  - [ ] Mention cibernox for `Ember.K` (96203e34)
- [ ] Release v2.11.0. 
  - [ ] Update package.json to use Ember-2.11 as default via `ember-source`.
  - [ ] Update ember-try.js
  - [ ] Also update for ember-cli 2.11 release (**if timing works right**). 
 
