### PR TITLE
Remove deprecated Ember.K

### DIFF
--- a/addon/states.js
+++ b/addon/states.js
@@ -57,11 +57,11 @@ var FragmentRootState = {
 
   didSetProperty: didSetProperty,
 
-  propertyWasReset: Ember.K,
+  propertyWasReset() {},
 
-  becomeDirty: Ember.K,
+  becomeDirty() {},
 
-  rolledBack: Ember.K,
+  rolledBack() {},
 
   empty: {
     isEmpty: true,
@@ -95,9 +95,9 @@ var FragmentRootState = {
         }
       },
 
-      pushedData: Ember.K,
+      pushedData() {},
 
-      didCommit: Ember.K,
+      didCommit() {},
 
       becomeDirty: function(internalModel) {
         internalModel.transitionTo('updated');


### PR DESCRIPTION
`Ember.K` has been deprecated and will be removed in 3.0, so it's time to remove it here too.