### PR TITLE
Added `store.isFragment`

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -46,7 +46,7 @@ Store.reopen({
   createFragment: function(modelName, props) {
     var type = this.modelFor(modelName);
 
-    Ember.assert("The '" + type + "' model must be a subclass of MF.Fragment", Fragment.detect(type));
+    Ember.assert("The '" + type + "' model must be a subclass of MF.Fragment", this.isFragment(type));
 
     var internalModel = new InternalModel(type, null, this, getOwner(this).container);
 
@@ -68,6 +68,19 @@ Store.reopen({
     fragment._isFragment = true;
 
     return fragment;
+  },
+
+  /**
+    Returns true if the modelName is a fragment, false if not
+
+    @method isFragment
+    @private
+    @param {String} the modelName to check if a fragment
+    @return {boolean}
+  */
+  isFragment(modelName) {
+    var type = this.modelFor(modelName);
+    return Fragment.detect(type);
   },
 
   /**

--- a/tests/unit/store_test.js
+++ b/tests/unit/store_test.js
@@ -38,6 +38,11 @@ test("attempting to create a fragment type that does not inherit from `MF.Fragme
   });
 });
 
+test("the store has an `isFragment` method", function(assert) {
+  assert.ok(store.isFragment('name'), 'a fragment should return true');
+  assert.notOk(store.isFragment('person', 'a model should return false'));
+});
+
 test("the default fragment serializer does not use the application serializer", function(assert) {
   var Serializer = JSONAPISerializer.extend();
   owner.register('serializer:application', Serializer);


### PR DESCRIPTION
[`ember-data-factory-guy`](https://github.com/danielspaniel/ember-data-factory-guy) currently relies on [`store.createFragment` raising an exception](https://github.com/danielspaniel/ember-data-factory-guy/blob/20ba57cafaa366b59e62fd9e1afef01d5d673c53/addon/model-definition.js#L41-L50) to detect if a model is a factory. This exception comes from an assertion which will be stripped in certain builds once https://github.com/ember-cli/rfcs/pull/50 is adopted.

This PR introduces a `store.isFragment` method which will allow ember-data-factory-guy to do something like:

```js
isModelAFragment() {
    if(FactoryGuy.store.isFragment) {
      return FactoryGuy.store.isFragment(this.modelName);
    }

    return false;
}
```

There are currently failing tests on master, and the same on this branch. https://github.com/lytics/ember-data-model-fragments/pull/227 seems to fix them and will likely land soon