### PR TITLE
Remove lookupSerializer deprecation

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -112,7 +112,7 @@ Store.reopen({
         '-default'
       ];
 
-      return this.lookupSerializer(modelName, fallbacks);
+      return this._super(modelName, fallbacks);
     }
 
     return this._super(modelOrClass);


### PR DESCRIPTION
On the latest stable build of ember data `lookupSerializer` is marked as deprecated and aliased towards `serializerFor` which makes infinite loop.

See https://github.com/emberjs/data/blob/v2.11.0/addon/-private/system/store.js#L2608