### PR TITLE
ES6-ify this addon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - $HOME/.cache # includes bowers cache
 
 env:
+  - EMBER_TRY_SCENARIO=ember-2-11
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ With a JSON payload of:
 The `name` attribute can be treated similar to a `belongsTo` relationship:
 
 ```javascript
-var person = store.getById('person', '1');
-var name = person.get('name');
+let person = store.getById('person', '1');
+let name = person.get('name');
 
 person.get('isDirty'); // false
 name.get('first'); // 'Tyrion'
@@ -155,9 +155,9 @@ person.get('isDirty'); // false
 The `addresses` attribute can be treated similar to a `hasMany` relationship:
 
 ```javascript
-var person = store.getById('person', '1');
-var addresses = person.get('addresses');
-var address = addresses.get('lastObject');
+let person = store.getById('person', '1');
+let addresses = person.get('addresses');
+let address = addresses.get('lastObject');
 
 person.get('isDirty'); // false
 address.get('country'); // 'Westeros'
@@ -193,8 +193,8 @@ person.set('addresses', [
 The `titles` attribute can be treated as an `Ember.Array`:
 
 ```javascript
-var person = store.getById('person', '1');
-var titles = person.get('titles');
+let person = store.getById('person', '1');
+let titles = person.get('titles');
 
 person.get('isDirty'); // false
 titles.get('length'); // 2
@@ -230,8 +230,8 @@ export default Model.extend({
 Since JavaScript objects and arrays are passed by reference, the value of `defaultValue` is copied using `Ember.copy` in order to prevent all instances sharing the same value. If a `defaultValue` option is not specified, `fragment` properties default to `null` and `fragmentArray` properties default to an empty array. Note that this may cause confusion when creating a record with a `fragmentArray` property:
 
 ```javascript
-var person = store.createRecord('person');
-var addresses = person.get('addresses'); // null
+let person = store.createRecord('person');
+let addresses = person.get('addresses'); // null
 
 // Fails with "Cannot read property 'createFragment' of null"
 addresses.createFragment({
@@ -248,7 +248,7 @@ import { fragment } from 'model-fragments/attributes';
 
 export default Model.extend({
   name: fragment('name', {
-    defaultValue: function() {
+    defaultValue() {
       return {
         first: 'Unsullied',
         last: Ember.uuid()
@@ -320,23 +320,23 @@ If custom serialization of the owner record is needed, fragment [snapshots](http
 import JSONSerializer from 'ember-data/serializers/json';
 
 export default JSONSerializer.extend({
-  serialize: function(snapshot, options) {
-    var json = this._super(snapshot, options);
+  serialize(snapshot, options) {
+    let json = this._super(...arguments);
 
     // Returns a `Snapshot` instance of the fragment
-    var nameSnapshot = snapshot.attr('name');
+    let nameSnapshot = snapshot.attr('name');
 
     json.full_name = nameSnapshot.attr('given') + ' ' + nameSnapshot.attr('family');
 
     // Returns a plain array of `Snapshot` instances
-    var addressSnapshots = snapshot.attr('addresses');
+    let addressSnapshots = snapshot.attr('addresses');
 
     json.countries = addressSnapshots.map(function(addressSnapshot) {
       return addressSnapshot.attr('country');
     });
 
     // Returns a plain array of primitives
-    var titlesSnapshot = snapshot.attr('titles');
+    let titlesSnapshot = snapshot.attr('titles');
 
     json.title_count = titlesSnapshot.length;
 
@@ -424,8 +424,8 @@ With a JSON payload of:
 Dirty state propagates up to the parent record, rollback cascades down:
 
 ```javascript
-var user = store.getById('user', '1');
-var product = user.get('orders.firstObject.products.lastObject');
+let user = store.getById('user', '1');
+let product = user.get('orders.firstObject.products.lastObject');
 
 user.get('isDirty'); // false
 product.get('price'); // '299.99'
@@ -534,8 +534,8 @@ Serializing the fragment type back to JSON is not currently supported out of the
 import JSONSerializer from 'ember-data/serializers/json';
 
 export default JSONSerializer.extend({
-  serialize: function(record, options) {
-    var json = this._super(record, options);
+  serialize(record, options) {
+    let json = this._super(...arguments);
 
     if (record instanceof App.Elephant) {
       json.$type = 'elephant';

--- a/addon/array/fragment.js
+++ b/addon/array/fragment.js
@@ -14,30 +14,31 @@ import map from '../util/map';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
-var setProperties = Ember.setProperties;
-var computed = Ember.computed;
-var typeOf = Ember.typeOf;
+const get = Ember.get;
+const setProperties = Ember.setProperties;
+const computed = Ember.computed;
+const typeOf = Ember.typeOf;
 
 // Normalizes an array of object literals or fragments into fragment instances,
 // reusing fragments from a source content array when possible
 function normalizeFragmentArray(array, content, objs, canonical) {
-  var record = get(array, 'owner');
-  var store = get(record, 'store');
-  var declaredModelName = get(array, 'type');
-  var options = get(array, 'options');
-  var key = get(array, 'name');
-  var fragment;
+  let record = get(array, 'owner');
+  let store = get(record, 'store');
+  let declaredModelName = get(array, 'type');
+  let options = get(array, 'options');
+  let key = get(array, 'name');
+  let fragment;
 
-  return map(objs, function(data, index) {
-    Ember.assert("You can only add '" + get(array, 'type') + "' fragments or object literals to this property", typeOf(data) === 'object' || isInstanceOfType(store.modelFor(get(array, 'type')), data));
+  return map(objs, (data, index) => {
+    let type = get(array, 'type');
+    Ember.assert(`You can only add '${type}' fragments or object literals to this property`, typeOf(data) === 'object' || isInstanceOfType(store.modelFor(type), data));
 
     if (isFragment(data)) {
       fragment = data;
 
-      var owner = internalModelFor(fragment)._owner;
+      let owner = internalModelFor(fragment)._owner;
 
-      Ember.assert("Fragments can only belong to one owner, try copying instead", !owner || owner === record);
+      Ember.assert('Fragments can only belong to one owner, try copying instead', !owner || owner === record);
 
       if (!owner) {
         setFragmentOwner(fragment, record, key);
@@ -72,7 +73,7 @@ function normalizeFragmentArray(array, content, objs, canonical) {
   @namespace MF
   @extends StatefulArray
 */
-var FragmentArray = StatefulArray.extend({
+const FragmentArray = StatefulArray.extend({
   /**
     The type of fragments the array contains
 
@@ -89,8 +90,8 @@ var FragmentArray = StatefulArray.extend({
     @private
     @param {Object} data
   */
-  _normalizeData: function(data) {
-    var content = get(this, 'content');
+  _normalizeData(data) {
+    let content = get(this, 'content');
 
     return normalizeFragmentArray(this, content, data, true);
   },
@@ -99,9 +100,9 @@ var FragmentArray = StatefulArray.extend({
     @method _createSnapshot
     @private
   */
-  _createSnapshot: function() {
+  _createSnapshot() {
     // Snapshot each fragment
-    return this.map(function(fragment) {
+    return this.map(fragment => {
       return fragment._createSnapshot();
     });
   },
@@ -109,8 +110,8 @@ var FragmentArray = StatefulArray.extend({
   /**
     @method _flushChangedAttributes
   */
-  _flushChangedAttributes: function() {
-    this.map(function(fragment) {
+  _flushChangedAttributes() {
+    this.map(fragment => {
       fragment._flushChangedAttributes();
     });
   },
@@ -119,12 +120,12 @@ var FragmentArray = StatefulArray.extend({
     @method _adapterDidCommit
     @private
   */
-  _adapterDidCommit: function(data) {
-    this._super(data);
+  _adapterDidCommit(data) {
+    this._super(...arguments);
 
     // Notify all records of commit; if the adapter update did not contain new
     // data, just notify each fragment so it can transition to a clean state
-    this.forEach(function(fragment, index) {
+    this.forEach((fragment, index) => {
       fragment._adapterDidCommit(data && data[index]);
     });
   },
@@ -133,12 +134,12 @@ var FragmentArray = StatefulArray.extend({
     @method _adapterDidError
     @private
   */
-  _adapterDidError: function(error) {
-    this._super(error);
+  _adapterDidError(error) {
+    this._super(...arguments);
 
     // Notify all records of the error; if the adapter update did not contain new
     // data, just notify each fragment so it can transition to a clean state
-    this.forEach(function(fragment) {
+    this.forEach(fragment => {
       fragment._adapterDidError(error);
     });
   },
@@ -161,7 +162,7 @@ var FragmentArray = StatefulArray.extend({
     @readOnly
   */
   hasDirtyAttributes: computed('@each.hasDirtyAttributes', '_originalState', function() {
-    return this._super() || this.isAny('hasDirtyAttributes');
+    return this._super(...arguments) || this.isAny('hasDirtyAttributes');
   }),
 
   /**
@@ -180,8 +181,8 @@ var FragmentArray = StatefulArray.extend({
 
     @method rollbackAttributes
   */
-  rollbackAttributes: function() {
-    this._super();
+  rollbackAttributes() {
+    this._super(...arguments);
     this.invoke('rollbackAttributes');
   },
 
@@ -192,7 +193,7 @@ var FragmentArray = StatefulArray.extend({
     @method serialize
     @return {Array}
   */
-  serialize: function() {
+  serialize() {
     return this.invoke('serialize');
   },
 
@@ -202,10 +203,10 @@ var FragmentArray = StatefulArray.extend({
     @method replaceContent
     @private
   */
-  replaceContent: function(index, amount, objs) {
-    var content = get(this, 'content');
-    var replacedContent = content.slice(index, index + amount);
-    var fragments = normalizeFragmentArray(this, replacedContent, objs);
+  replaceContent(index, amount, objs) {
+    let content = get(this, 'content');
+    let replacedContent = content.slice(index, index + amount);
+    let fragments = normalizeFragmentArray(this, replacedContent, objs);
 
     return content.replace(index, amount, fragments);
   },
@@ -218,7 +219,7 @@ var FragmentArray = StatefulArray.extend({
     @param {MF.Fragment} fragment
     @return {MF.Fragment} the newly added fragment
   */
-  addFragment: function(fragment) {
+  addFragment(fragment) {
     return this.addObject(fragment);
   },
 
@@ -229,7 +230,7 @@ var FragmentArray = StatefulArray.extend({
     @param {MF.Fragment} fragment
     @return {MF.Fragment} the removed fragment
   */
-  removeFragment: function(fragment) {
+  removeFragment(fragment) {
     return this.removeObject(fragment);
   },
 
@@ -241,25 +242,25 @@ var FragmentArray = StatefulArray.extend({
     @param {MF.Fragment} fragment
     @return {MF.Fragment} the newly added fragment
     */
-  createFragment: function(props) {
-    var record = get(this, 'owner');
-    var store = get(record, 'store');
-    var type = get(this, 'type');
-    var fragment = store.createFragment(type, props);
+  createFragment(props) {
+    let record = get(this, 'owner');
+    let store = get(record, 'store');
+    let type = get(this, 'type');
+    let fragment = store.createFragment(type, props);
 
     return this.pushObject(fragment);
   },
 
-  willDestroy: function() {
-    this._super.apply(this, arguments);
+  willDestroy() {
+    this._super(...arguments);
 
     // destroy the current state
-    this.forEach(function(fragment) {
+    this.forEach(fragment => {
       fragment.destroy();
     });
 
     // destroy the original state
-    this._originalState.forEach(function(fragment) {
+    this._originalState.forEach(fragment => {
       fragment.destroy();
     });
   }

--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -5,11 +5,11 @@ import { fragmentDidDirty, fragmentDidReset } from '../states';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
-var set = Ember.set;
-var computed = Ember.computed;
-var copy = Ember.copy;
-var makeArray = Ember.makeArray;
+const get = Ember.get;
+const set = Ember.set;
+const computed = Ember.computed;
+const copy = Ember.copy;
+const makeArray = Ember.makeArray;
 
 /**
   A state-aware array that is tied to an attribute of a `DS.Model` instance.
@@ -18,7 +18,7 @@ var makeArray = Ember.makeArray;
   @namespace MF
   @extends Ember.ArrayProxy
 */
-var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
+const StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
   /**
     A reference to the array's owner record.
 
@@ -36,8 +36,8 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
   */
   name: null,
 
-  init: function() {
-    this._super();
+  init() {
+    this._super(...arguments);
     this._pendingData = undefined;
     set(this, '_originalState', []);
   },
@@ -52,7 +52,7 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     @method copy
     @return {array} a new array
   */
-  copy: function() {
+  copy() {
     return this.map(copy);
   },
 
@@ -61,7 +61,7 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     @private
     @param {Object} data
   */
-  setupData: function(data) {
+  setupData(data) {
     // Since replacing the contents of the array can trigger changes to fragment
     // array properties, this method can get invoked recursively with the same
     // data, so short circuit here once it's been setup the first time
@@ -71,8 +71,8 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
 
     this._pendingData = data;
 
-    var processedData = this._normalizeData(makeArray(data));
-    var content = get(this, 'content');
+    let processedData = this._normalizeData(makeArray(data));
+    let content = get(this, 'content');
 
     // This data is canonical, so create rollback point
     set(this, '_originalState', processedData);
@@ -88,7 +88,7 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     @private
     @param {Object} data
   */
-  _normalizeData: function(data) {
+  _normalizeData(data) {
     return data;
   },
 
@@ -96,7 +96,7 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     @method _createSnapshot
     @private
   */
-  _createSnapshot: function() {
+  _createSnapshot() {
     // Since elements are not models, a snapshot is simply a mapping of raw values
     return this.toArray();
   },
@@ -104,13 +104,13 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
   /**
     @method _flushChangedAttributes
   */
-  _flushChangedAttributes: function() {},
+  _flushChangedAttributes() {},
 
   /**
     @method _adapterDidCommit
     @private
   */
-  _adapterDidCommit: function(data) {
+  _adapterDidCommit(data) {
     if (data) {
       this.setupData(data);
     } else {
@@ -119,7 +119,7 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     }
   },
 
-  _adapterDidError: function(/*error*/) {
+  _adapterDidError(/*error*/) {
     // No-Op
   },
 
@@ -161,7 +161,7 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
 
     @method rollbackAttributes
   */
-  rollbackAttributes: function() {
+  rollbackAttributes() {
     this.setObjects(get(this, '_originalState'));
   },
 
@@ -171,15 +171,15 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     @method serialize
     @return {Array}
   */
-  serialize: function() {
+  serialize() {
     return this.toArray();
   },
 
-  arrayContentDidChange: function() {
-    this._super.apply(this, arguments);
+  arrayContentDidChange() {
+    this._super(...arguments);
 
-    var record = get(this, 'owner');
-    var key = get(this, 'name');
+    let record = get(this, 'owner');
+    let key = get(this, 'name');
 
     // Any change to the size of the fragment array means a potential state change
     if (get(this, 'hasDirtyAttributes')) {
@@ -189,8 +189,9 @@ var StatefulArray = Ember.ArrayProxy.extend(Ember.Copyable, {
     }
   },
 
-  toStringExtension: function() {
-    return 'owner(' + get(this, 'owner.id') + ')';
+  toStringExtension() {
+    let ownerId = get(this, 'owner.id');
+    return `owner(${ownerId})`;
   }
 });
 

--- a/addon/attributes.js
+++ b/addon/attributes.js
@@ -18,20 +18,20 @@ import isInstanceOfType from './util/instance-of-type';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
-var setProperties = Ember.setProperties;
-var isArray = Ember.isArray;
-var typeOf = Ember.typeOf;
-var copy = Ember.copy;
-var computed = Ember.computed;
+const get = Ember.get;
+const setProperties = Ember.setProperties;
+const isArray = Ember.isArray;
+const typeOf = Ember.typeOf;
+const copy = Ember.copy;
+const computed = Ember.computed;
 
 // Create a unique type string for the combination of fragment property type,
 // transform type (or fragment model), and polymorphic type key
 function metaTypeFor(name, type, options) {
-  var metaType = '-mf-' + name;
+  let metaType = `-mf-${name}`;
 
   if (type) {
-    metaType += '$' + type;
+    metaType += `$${type}`;
   }
 
   if (options && options.polymorphic) {
@@ -80,12 +80,12 @@ function metaTypeFor(name, type, options) {
 function fragment(declaredModelName, options) {
   options = options || {};
 
-  var metaType = metaTypeFor('fragment', declaredModelName, options);
+  let metaType = metaTypeFor('fragment', declaredModelName, options);
 
   function setupFragment(store, record, key) {
-    var internalModel = internalModelFor(record);
-    var data = getWithDefault(internalModel, key, options, 'object');
-    var fragment = internalModel._fragments[key];
+    let internalModel = internalModelFor(record);
+    let data = getWithDefault(internalModel, key, options, 'object');
+    let fragment = internalModel._fragments[key];
 
     // Regardless of whether being called as a setter or getter, the fragment
     // may not be initialized yet, in which case the data will contain a
@@ -114,10 +114,10 @@ function fragment(declaredModelName, options) {
   }
 
   function setFragmentValue(record, key, fragment, value) {
-    var store = record.store;
-    var internalModel = internalModelFor(record);
+    let store = record.store;
+    let internalModel = internalModelFor(record);
 
-    Ember.assert("You can only assign `null`, an object literal or a '" + declaredModelName + "' fragment instance to this property", value === null || typeOf(value) === 'object' || isInstanceOfType(store.modelFor(declaredModelName), value));
+    Ember.assert(`You can only assign \`null\`, an object literal or a '${declaredModelName}' fragment instance to this property`, value === null || typeOf(value) === 'object' || isInstanceOfType(store.modelFor(declaredModelName), value));
 
     if (!value) {
       fragment = null;
@@ -191,7 +191,7 @@ function fragment(declaredModelName, options) {
 function fragmentArray(modelName, options) {
   options || (options = {});
 
-  var metaType = metaTypeFor('fragment-array', modelName, options);
+  let metaType = metaTypeFor('fragment-array', modelName, options);
 
   return fragmentArrayProperty(metaType, options, function createFragmentArray(record, key) {
     return FragmentArray.create({
@@ -239,7 +239,7 @@ function array(type, options) {
     options || (options = {});
   }
 
-  var metaType = metaTypeFor('array', type);
+  let metaType = metaTypeFor('array', type);
 
   return fragmentArrayProperty(metaType, options, function createStatefulArray(record, key) {
     return StatefulArray.create({
@@ -253,7 +253,7 @@ function array(type, options) {
 function fragmentProperty(type, options, setupFragment, setFragmentValue) {
   options = options || {};
 
-  var meta = {
+  let meta = {
     type: type,
     isAttribute: true,
     isFragment: true,
@@ -261,15 +261,15 @@ function fragmentProperty(type, options, setupFragment, setFragmentValue) {
   };
 
   return computed({
-    get: function(key) {
-      var internalModel = internalModelFor(this);
-      var fragment = setupFragment(this.store, this, key);
+    get(key) {
+      let internalModel = internalModelFor(this);
+      let fragment = setupFragment(this.store, this, key);
 
       return internalModel._fragments[key] = fragment;
     },
-    set: function(key, value) {
-      var internalModel = internalModelFor(this);
-      var fragment = setupFragment(this.store, this, key);
+    set(key, value) {
+      let internalModel = internalModelFor(this);
+      let fragment = setupFragment(this.store, this, key);
 
       fragment = setFragmentValue(this, key, fragment, value);
 
@@ -280,9 +280,9 @@ function fragmentProperty(type, options, setupFragment, setFragmentValue) {
 
 function fragmentArrayProperty(metaType, options, createArray) {
   function setupFragmentArray(store, record, key) {
-    var internalModel = internalModelFor(record);
-    var data = getWithDefault(internalModel, key, options, 'array');
-    var fragments = internalModel._fragments[key] || null;
+    let internalModel = internalModelFor(record);
+    let data = getWithDefault(internalModel, key, options, 'array');
+    let fragments = internalModel._fragments[key] || null;
 
     // If we already have a processed fragment in _data and our current fragment is
     // null simply reuse the one from data. We can be in this state after a rollback
@@ -303,7 +303,7 @@ function fragmentArrayProperty(metaType, options, createArray) {
   }
 
   function setFragmentValue(record, key, fragments, value) {
-    var internalModel = internalModelFor(record);
+    let internalModel = internalModelFor(record);
 
     if (isArray(value)) {
       fragments || (fragments = createArray(record, key));
@@ -311,7 +311,7 @@ function fragmentArrayProperty(metaType, options, createArray) {
     } else if (value === null) {
       fragments = null;
     } else {
-      Ember.assert("A fragment array property can only be assigned an array or null");
+      Ember.assert('A fragment array property can only be assigned an array or null');
     }
 
     if (internalModel._data[key] !== fragments || get(fragments, 'hasDirtyAttributes')) {
@@ -351,7 +351,7 @@ function fragmentArrayProperty(metaType, options, createArray) {
 */
 function fragmentOwner() {
   return computed(function() {
-    Ember.assert("Fragment owner properties can only be used on fragments.", isFragment(this));
+    Ember.assert('Fragment owner properties can only be used on fragments.', isFragment(this));
 
     return internalModelFor(this)._owner;
   }).meta({
@@ -362,7 +362,7 @@ function fragmentOwner() {
 // The default value of a fragment is either an array or an object,
 // which should automatically get deep copied
 function getDefaultValue(record, options, type) {
-  var value;
+  let value;
 
   if (typeof options.defaultValue === 'function') {
     value = options.defaultValue();
@@ -374,7 +374,7 @@ function getDefaultValue(record, options, type) {
     return null;
   }
 
-  Ember.assert("The fragment's default value must be an " + type, (typeOf(value) == type) || (value === null));
+  Ember.assert(`The fragment's default value must be an ${type}`, (typeOf(value) == type) || (value === null));
 
   // Create a deep copy of the resulting value to avoid shared reference errors
   return copy(value, true);

--- a/addon/ext.js
+++ b/addon/ext.js
@@ -15,12 +15,12 @@ import FragmentArray from './array/fragment';
   @module ember-data-model-fragments
 */
 
-var keys = Object.keys || Ember.keys;
-var create = Object.create || Ember.create;
-var getOwner = Ember.getOwner;
+const keys = Object.keys || Ember.keys;
+const create = Object.create || Ember.create;
+const getOwner = Ember.getOwner;
 
-var InternalModelPrototype = InternalModel.prototype;
-var internalModelExpectsModelName = InternalModelPrototype.hasOwnProperty('modelClass');
+let InternalModelPrototype = InternalModel.prototype;
+const internalModelExpectsModelName = InternalModelPrototype.hasOwnProperty('modelClass');
 
 
 /**
@@ -37,8 +37,8 @@ Store.reopen({
 
     ```js
     store.createFragment('name', {
-      first: "Alex",
-      last: "Routé"
+      first: 'Alex',
+      last: 'Routé'
     });
     ```
 
@@ -48,16 +48,16 @@ Store.reopen({
       newly created fragment.
     @return {MF.Fragment} fragment
   */
-  createFragment: function(modelName, props) {
-    Ember.assert("The '" + modelName + "' model must be a subclass of MF.Fragment", this.isFragment(modelName));
+  createFragment(modelName, props) {
+    Ember.assert(`The '${modelName}' model must be a subclass of MF.Fragment`, this.isFragment(modelName));
 
-    var internalModel;
+    let internalModel;
     if (internalModelExpectsModelName) {
       internalModel = new InternalModel(modelName, null, this, getOwner(this).container);
     } else {
       // BACKWARDS_COMPAT: <= Ember 2.11 the `InternalModel` expected the class,
       // rather than the modelName, as it's first argument.
-      var type = this.modelFor(modelName);
+      let type = this.modelFor(modelName);
       internalModel = new InternalModel(type, null, this, getOwner(this).container);
     }
 
@@ -69,7 +69,7 @@ Store.reopen({
 
     internalModel.loadedData();
 
-    var fragment = internalModel.getRecord();
+    let fragment = internalModel.getRecord();
 
     if (props) {
       fragment.setProperties(props);
@@ -90,7 +90,7 @@ Store.reopen({
     @return {boolean}
   */
   isFragment(modelName) {
-    var type = this.modelFor(modelName);
+    let type = this.modelFor(modelName);
     return Fragment.detect(type);
   }
 });
@@ -118,7 +118,7 @@ Model.reopen({
       last  : DS.attr('string')
     });
 
-    var person = store.createRecord('person');
+    let person = store.createRecord('person');
     person.changedAttributes(); // {}
     person.get('name').set('first', 'Tomster');
     person.set('type', 'Hamster');
@@ -129,26 +129,26 @@ Model.reopen({
     @return {Object} an object, whose keys are changed properties,
       and value is an [oldProp, newProp] array.
   */
-  changedAttributes: function() {
-    var diffData = this._super();
-    var internalModel = internalModelFor(this);
+  changedAttributes() {
+    let diffData = this._super(...arguments);
+    let internalModel = internalModelFor(this);
 
-    keys(internalModel._fragments).forEach(function(name) {
+    keys(internalModel._fragments).forEach(name => {
       // An actual diff of the fragment or fragment array is outside the scope
       // of this method, so just indicate that there is a change instead
       if (name in internalModel._attributes) {
         diffData[name] = true;
       }
-    }, this);
+    });
 
     return diffData;
   },
 
-  willDestroy: function() {
-    this._super.apply(this, arguments);
+  willDestroy() {
+    this._super(...arguments);
 
-    var internalModel = internalModelFor(this);
-    var key, fragment;
+    let internalModel = internalModelFor(this);
+    let key, fragment;
 
     // destroy the current state
     for (key in internalModel._fragments) {
@@ -171,10 +171,10 @@ Model.reopen({
 // Replace a method on an object with a new one that calls the original and then
 // invokes a function with the result
 function decorateMethod(obj, name, fn) {
-  var originalFn = obj[name];
+  let originalFn = obj[name];
 
   obj[name] = function() {
-    var value = originalFn.apply(this, arguments);
+    let value = originalFn.apply(this, arguments);
 
     return fn.call(this, value, arguments);
   };
@@ -188,10 +188,10 @@ function decorateMethod(obj, name, fn) {
   @private
 */
 decorateMethod(InternalModelPrototype, 'createSnapshot', function createFragmentSnapshot(snapshot) {
-  var attrs = snapshot._attributes;
+  let attrs = snapshot._attributes;
 
-  keys(attrs).forEach(function(key) {
-    var attr = attrs[key];
+  keys(attrs).forEach(key => {
+    let attr = attrs[key];
 
     // If the attribute has a `_createSnapshot` method, invoke it before the
     // snapshot gets passed to the serializer
@@ -220,7 +220,7 @@ decorateMethod(InternalModelPrototype, 'createSnapshot', function createFragment
   @method rollbackAttributes
 */
 decorateMethod(InternalModelPrototype, 'rollbackAttributes', function rollbackFragments() {
-  for (var key in this._fragments) {
+  for (let key in this._fragments) {
     if (this._fragments[key]) {
       this._fragments[key].rollbackAttributes();
     }
@@ -234,10 +234,10 @@ decorateMethod(InternalModelPrototype, 'rollbackAttributes', function rollbackFr
   @method flushChangedAttributes
 */
 decorateMethod(InternalModelPrototype, 'flushChangedAttributes', function flushChangedAttributesFragments() {
-  var fragment;
+  let fragment;
 
   // Notify fragments that the record was committed
-  for (var key in this._fragments) {
+  for (let key in this._fragments) {
     if (fragment = this._fragments[key]) {
       fragment._flushChangedAttributes();
     }
@@ -252,11 +252,11 @@ decorateMethod(InternalModelPrototype, 'flushChangedAttributes', function flushC
   @method adapterDidCommit
 */
 decorateMethod(InternalModelPrototype, 'adapterDidCommit', function adapterDidCommitFragments(returnValue, args) {
-  var attributes = (args[0] && args[0].attributes) || create(null);
-  var fragment;
+  let attributes = (args[0] && args[0].attributes) || create(null);
+  let fragment;
 
   // Notify fragments that the record was committed
-  for (var key in this._fragments) {
+  for (let key in this._fragments) {
     if (fragment = this._fragments[key]) {
       fragment._adapterDidCommit(attributes[key]);
     }
@@ -264,11 +264,11 @@ decorateMethod(InternalModelPrototype, 'adapterDidCommit', function adapterDidCo
 });
 
 decorateMethod(InternalModelPrototype, 'adapterDidError', function adapterDidErrorFragments(returnValue, args) {
-  var error = args[0] || create(null);
-  var fragment;
+  let error = args[0] || create(null);
+  let fragment;
 
   // Notify fragments that the record was committed
-  for (var key in this._fragments) {
+  for (let key in this._fragments) {
     if (fragment = this._fragments[key]) {
       fragment._adapterDidError(error);
     }
@@ -287,31 +287,31 @@ JSONSerializer.reopen({
     @method transformFor
     @private
   */
-  transformFor: function(attributeType) {
+  transformFor(attributeType) {
     if (attributeType.indexOf('-mf-') === 0) {
       return getFragmentTransform(getOwner(this), this.store, attributeType);
     }
 
-    return this._super.apply(this, arguments);
+    return this._super(...arguments);
   }
 });
 
 // Retrieve or create a transform for the specific fragment type
 function getFragmentTransform(owner, store, attributeType) {
-  var containerKey = 'transform:' + attributeType;
-  var match = attributeType.match(/^-mf-(fragment|fragment-array|array)(?:\$([^$]+))?(?:\$(.+))?$/);
-  var transformName = match[1];
-  var transformType = match[2];
-  var polymorphicTypeProp = match[3];
+  let containerKey = `transform:${attributeType}`;
+  let match = attributeType.match(/^-mf-(fragment|fragment-array|array)(?:\$([^$]+))?(?:\$(.+))?$/);
+  let transformName = match[1];
+  let transformType = match[2];
+  let polymorphicTypeProp = match[3];
 
   if (!owner.hasRegistration(containerKey)) {
-    var transformClass;
+    let transformClass;
     if (owner.factoryFor) {
-      transformClass = owner.factoryFor('transform:' + transformName);
+      transformClass = owner.factoryFor(`transform:${transformName}`);
       transformClass = transformClass && transformClass.class;
     } else {
       // BACKWARDS_COMPAT: <= Ember 2.11
-      transformClass = owner._lookupFactory('transform:' + transformName);
+      transformClass = owner._lookupFactory(`transform:${transformName}`);
     }
 
     owner.register(containerKey, transformClass.extend({
@@ -332,11 +332,11 @@ function getFragmentTransform(owner, store, attributeType) {
   See: https://github.com/lytics/ember-data-model-fragments/issues/224
 */
 (function patchContainerInstanceCache(instanceCache) {
-  var ContainerInstanceCachePrototype = ContainerInstanceCache.prototype;
-  var _super = ContainerInstanceCachePrototype._fallbacksFor;
+  let ContainerInstanceCachePrototype = ContainerInstanceCache.prototype;
+  let _super = ContainerInstanceCachePrototype._fallbacksFor;
   ContainerInstanceCachePrototype._fallbacksFor = function _modelFragmentsPatchedFallbacksFor(namespace, preferredKey) {
     if (namespace === 'serializer') {
-      var model = this._store.modelFactoryFor(preferredKey);
+      let model = this._store.modelFactoryFor(preferredKey);
       if (model && Fragment.detect(model)) {
         return [
           '-fragment',

--- a/addon/fragment.js
+++ b/addon/fragment.js
@@ -6,9 +6,9 @@ import { Model } from './ext';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
-var create = Object.create || Ember.create;
-var copy = Ember.copy;
+const get = Ember.get;
+const create = Object.create || Ember.create;
+const copy = Ember.copy;
 
 /**
   The class that all nested object structures, or 'fragments', descend from.
@@ -36,17 +36,17 @@ var copy = Ember.copy;
 
   ```json
   {
-    "id": "1",
-    "name": {
-      "first": "Robert",
-      "last": "Jackson"
+    'id': '1',
+    'name': {
+      'first': 'Robert',
+      'last': 'Jackson'
     }
   }
   ```
 
   ```javascript
-  var person = store.getbyid('person', '1');
-  var name = person.get('name');
+  let person = store.getbyid('person', '1');
+  let name = person.get('name');
 
   person.get('hasDirtyAttributes'); // false
   name.get('hasDirtyAttributes'); // false
@@ -68,7 +68,7 @@ var copy = Ember.copy;
   @uses Ember.Comparable
   @uses Ember.Copyable
 */
-var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
+const Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
   /**
     Compare two fragments by identity to allow `FragmentArray` to diff arrays.
 
@@ -77,7 +77,7 @@ var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
     @param b {MF.Fragment} the second fragment to compare
     @return {Integer} the result of the comparison
   */
-  compare: function(f1, f2) {
+  compare(f1, f2) {
     return f1 === f2 ? 0 : 1;
   },
 
@@ -89,15 +89,15 @@ var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
     @method copy
     @return {MF.Fragment} the newly created fragment
   */
-  copy: function() {
-    var type = this.constructor;
-    var props = create(null);
+  copy() {
+    let type = this.constructor;
+    let props = create(null);
 
     // Loop over each attribute and copy individually to ensure nested fragments
     // are also copied
-    type.eachAttribute(function(name) {
+    type.eachAttribute(name => {
       props[name] = copy(get(this, name));
-    }, this);
+    });
 
     return this.store.createFragment(type.modelName, props);
   },
@@ -105,14 +105,14 @@ var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
   /**
     @method _flushChangedAttributes
   */
-  _flushChangedAttributes: function() {
+  _flushChangedAttributes() {
     internalModelFor(this).flushChangedAttributes();
   },
 
   /**
     @method _adapterDidCommit
   */
-  _adapterDidCommit: function(data) {
+  _adapterDidCommit(data) {
     internalModelFor(this).adapterDidCommit({
       attributes: data || create(null)
     });
@@ -121,24 +121,25 @@ var Fragment = Model.extend(Ember.Comparable, Ember.Copyable, {
   /**
     @method _adapterDidCommit
   */
-  _adapterDidError: function(/*error*/) {
+  _adapterDidError(/*error*/) {
     internalModelFor(this)._saveWasRejected();
   },
 
-  toStringExtension: function() {
+  toStringExtension() {
     let internalModel = internalModelFor(this);
     let owner = internalModel && internalModel._owner;
     if (owner) {
-      return 'owner(' + get(owner, 'id') + ')';
+      let ownerId = get(owner, 'id');
+      return `owner(${ownerId})`;
     } else {
       return '';
     }
   }
 }).reopenClass({
   fragmentOwnerProperties: Ember.computed(function() {
-    var props = [];
+    let props = [];
 
-    this.eachComputedProperty(function(name, meta) {
+    this.eachComputedProperty((name, meta) => {
       if (meta.isFragmentOwner) {
         props.push(name);
       }
@@ -163,15 +164,15 @@ export function getActualFragmentType(declaredType, options, data) {
     return declaredType;
   }
 
-  var typeKey = options.typeKey || 'type';
-  var actualType = data[typeKey];
+  let typeKey = options.typeKey || 'type';
+  let actualType = data[typeKey];
 
   return actualType || declaredType;
 }
 
 // Returns the internal model for the given record/fragment
 export function internalModelFor(record) {
-  var internalModel = record._internalModel;
+  let internalModel = record._internalModel;
 
   // Ensure the internal model has a fragments hash, since we can't override the
   // constructor function anymore
@@ -184,15 +185,15 @@ export function internalModelFor(record) {
 
 // Sets the owner/key values on a fragment
 export function setFragmentOwner(fragment, record, key) {
-  var internalModel = internalModelFor(fragment);
+  let internalModel = internalModelFor(fragment);
 
-  Ember.assert("To preserve rollback semantics, fragments can only belong to one owner. Try copying instead", !internalModel._owner || internalModel._owner === record);
+  Ember.assert('To preserve rollback semantics, fragments can only belong to one owner. Try copying instead', !internalModel._owner || internalModel._owner === record);
 
   internalModel._owner = record;
   internalModel._name = key;
 
   // Notify any observers of `fragmentOwner` properties
-  get(fragment.constructor, 'fragmentOwnerProperties').forEach(function(name) {
+  get(fragment.constructor, 'fragmentOwnerProperties').forEach(name => {
     fragment.notifyPropertyChange(name);
   });
 
@@ -208,8 +209,8 @@ export function setFragmentData(fragment, data) {
 
 // Creates a fragment and sets its owner to the given record
 export function createFragment(store, declaredModelName, record, key, options, data) {
-  var actualModelName = getActualFragmentType(declaredModelName, options, data);
-  var fragment = store.createFragment(actualModelName);
+  let actualModelName = getActualFragmentType(declaredModelName, options, data);
+  let fragment = store.createFragment(actualModelName);
 
   setFragmentOwner(fragment, record, key);
   setFragmentData(fragment, data);

--- a/addon/index.js
+++ b/addon/index.js
@@ -18,7 +18,7 @@ import {
   @module ember-data-model-fragments
   @main ember-data-model-fragments
 */
-var MF = Ember.Namespace.create({
+const MF = Ember.Namespace.create({
   VERSION: VERSION,
   Fragment: Fragment,
   FragmentArray: FragmentArray,

--- a/addon/states.js
+++ b/addon/states.js
@@ -5,15 +5,15 @@ import RootState from 'ember-data/-private/system/model/states';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
-var create = Object.create || Ember.create;
+const get = Ember.get;
+const create = Object.create || Ember.create;
 
-var didSetProperty = RootState.loaded.saved.didSetProperty;
-var propertyWasReset = RootState.loaded.updated.uncommitted.propertyWasReset;
+const didSetProperty = RootState.loaded.saved.didSetProperty;
+const propertyWasReset = RootState.loaded.updated.uncommitted.propertyWasReset;
 
-var dirtySetup = function(internalModel) {
-  var record = internalModel._owner;
-  var key = internalModel._name;
+const dirtySetup = function(internalModel) {
+  let record = internalModel._owner;
+  let key = internalModel._name;
 
   // A newly created fragment may not have an owner yet
   if (record) {
@@ -44,7 +44,7 @@ var dirtySetup = function(internalModel) {
 
   @class FragmentRootState
 */
-var FragmentRootState = {
+let FragmentRootState = {
   // Include all `DS.Model` state booleans for consistency
   isEmpty: false,
   isLoading: false,
@@ -66,24 +66,24 @@ var FragmentRootState = {
   empty: {
     isEmpty: true,
 
-    loadedData: function(internalModel) {
+    loadedData(internalModel) {
       internalModel.transitionTo('loaded.created');
     },
 
-    pushedData: function(internalModel) {
+    pushedData(internalModel) {
       internalModel.transitionTo('loaded.saved');
     }
   },
 
   loaded: {
-    pushedData: function(internalModel) {
+    pushedData(internalModel) {
       internalModel.transitionTo('saved');
     },
 
     saved: {
-      setup: function(internalModel) {
-        var record = internalModel._owner;
-        var key = internalModel._name;
+      setup(internalModel) {
+        let record = internalModel._owner;
+        let key = internalModel._name;
 
         // Abort if fragment is still initializing
         if (!record._internalModel._fragments[key]) { return; }
@@ -99,7 +99,7 @@ var FragmentRootState = {
 
       didCommit() {},
 
-      becomeDirty: function(internalModel) {
+      becomeDirty(internalModel) {
         internalModel.transitionTo('updated');
       }
     },
@@ -111,7 +111,7 @@ var FragmentRootState = {
 
       setup: dirtySetup,
 
-      didCommit: function(internalModel) {
+      didCommit(internalModel) {
         internalModel.transitionTo('saved');
       }
     },
@@ -123,11 +123,11 @@ var FragmentRootState = {
 
       propertyWasReset: propertyWasReset,
 
-      didCommit: function(internalModel) {
+      didCommit(internalModel) {
         internalModel.transitionTo('saved');
       },
 
-      rolledBack: function(internalModel) {
+      rolledBack(internalModel) {
         internalModel.transitionTo('saved');
       }
     }
@@ -135,7 +135,7 @@ var FragmentRootState = {
 };
 
 function mixin(original, hash) {
-  for (var prop in hash) {
+  for (let prop in hash) {
     original[prop] = hash[prop];
   }
 
@@ -148,12 +148,12 @@ function wireState(object, parent, name) {
   object.parentState = parent;
   object.stateName = name;
 
-  for (var prop in object) {
+  for (let prop in object) {
     if (!object.hasOwnProperty(prop) || prop === 'parentState' || prop === 'stateName') {
       continue;
     }
     if (typeof object[prop] === 'object') {
-      object[prop] = wireState(object[prop], object, name + "." + prop);
+      object[prop] = wireState(object[prop], object, `${name}.${prop}`);
     }
   }
 

--- a/addon/transforms/array.js
+++ b/addon/transforms/array.js
@@ -6,10 +6,10 @@ import map from '../util/map';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
-var makeArray = Ember.makeArray;
-var computed = Ember.computed;
-var getOwner = Ember.getOwner;
+const get = Ember.get;
+const makeArray = Ember.makeArray;
+const computed = Ember.computed;
+const getOwner = Ember.getOwner;
 
 /**
   Transform for `MF.array` that transforms array data with the given transform
@@ -19,7 +19,7 @@ var getOwner = Ember.getOwner;
   @namespace MF
   @extends DS.Transform
 */
-var ArrayTransform = Transform.extend({
+const ArrayTransform = Transform.extend({
   store: null,
   type: null,
 
@@ -28,7 +28,7 @@ var ArrayTransform = Transform.extend({
       return null;
     }
 
-    var transform = get(this, 'transform');
+    let transform = get(this, 'transform');
 
     data = makeArray(data);
 
@@ -44,7 +44,7 @@ var ArrayTransform = Transform.extend({
       return null;
     }
 
-    var transform = get(this, 'transform');
+    let transform = get(this, 'transform');
 
     array = array.toArray ? array.toArray() : array;
 
@@ -56,14 +56,14 @@ var ArrayTransform = Transform.extend({
   },
 
   transform: computed('type', function() {
-    var attributeType = this.get('type');
+    let attributeType = this.get('type');
 
     if (!attributeType) {
       return null;
     }
 
-    var transform = getOwner(this).lookup('transform:' + attributeType);
-    Ember.assert("Unable to find transform for '" + attributeType + "'", !!transform);
+    let transform = getOwner(this).lookup(`transform:${attributeType}`);
+    Ember.assert(`Unable to find transform for '${attributeType}'`, !!transform);
 
     return transform;
   })

--- a/addon/transforms/fragment-array.js
+++ b/addon/transforms/fragment-array.js
@@ -13,13 +13,13 @@ import map from '../util/map';
   @namespace MF
   @extends DS.Transform
 */
-var FragmentArrayTransform = FragmentTransform.extend({
+const FragmentArrayTransform = FragmentTransform.extend({
   deserialize: function deserializeFragmentArray(data) {
     if (data == null) {
       return null;
     }
 
-    return map(data, function(datum) {
+    return map(data, datum => {
       return this.deserializeSingle(datum);
     }, this);
   },
@@ -29,11 +29,10 @@ var FragmentArrayTransform = FragmentTransform.extend({
       return null;
     }
 
-    var store = this.store;
+    let store = this.store;
 
-    return map(snapshots, function(snapshot) {
-      var serializer = store.serializerFor(snapshot.modelName);
-
+    return map(snapshots, snapshot => {
+      let serializer = store.serializerFor(snapshot.modelName);
       return serializer.serialize(snapshot);
     });
   }

--- a/addon/transforms/fragment.js
+++ b/addon/transforms/fragment.js
@@ -6,7 +6,7 @@ import JSONAPISerializer from 'ember-data/serializers/json-api';
   @module ember-data-model-fragments
 */
 
-var get = Ember.get;
+const get = Ember.get;
 
 /**
   Transform for `MF.fragment` fragment attribute which delegates work to
@@ -16,7 +16,7 @@ var get = Ember.get;
   @namespace MF
   @extends DS.Transform
 */
-var FragmentTransform = Transform.extend({
+const FragmentTransform = Transform.extend({
   store: null,
   type: null,
   polymorphicTypeProp: null,
@@ -34,15 +34,15 @@ var FragmentTransform = Transform.extend({
       return null;
     }
 
-    var store = this.store;
-    var serializer = store.serializerFor(snapshot.modelName);
+    let store = this.store;
+    let serializer = store.serializerFor(snapshot.modelName);
 
     return serializer.serialize(snapshot);
   },
 
-  modelNameFor: function modelNameFor(data) {
-    var modelName = get(this, 'type');
-    var polymorphicTypeProp = get(this, 'polymorphicTypeProp');
+  modelNameFor(data) {
+    let modelName = get(this, 'type');
+    let polymorphicTypeProp = get(this, 'polymorphicTypeProp');
 
     if (data && polymorphicTypeProp && data[polymorphicTypeProp]) {
       modelName = data[polymorphicTypeProp];
@@ -51,15 +51,15 @@ var FragmentTransform = Transform.extend({
     return modelName;
   },
 
-  deserializeSingle: function deserializeSingle(data) {
-    var store = this.store;
-    var modelName = this.modelNameFor(data);
-    var serializer = store.serializerFor(modelName);
+  deserializeSingle(data) {
+    let store = this.store;
+    let modelName = this.modelNameFor(data);
+    let serializer = store.serializerFor(modelName);
 
-    Ember.assert("The `JSONAPISerializer` is not suitable for model fragments, please use `JSONSerializer`", !(serializer instanceof JSONAPISerializer));
+    Ember.assert('The `JSONAPISerializer` is not suitable for model fragments, please use `JSONSerializer`', !(serializer instanceof JSONAPISerializer));
 
-    var typeClass = store.modelFor(modelName);
-    var serialized = serializer.normalize(typeClass, data);
+    let typeClass = store.modelFor(modelName);
+    let serialized = serializer.normalize(typeClass, data);
 
     // `JSONSerializer#normalize` returns a full JSON API document, but we only
     // need the attributes hash

--- a/addon/util/map.js
+++ b/addon/util/map.js
@@ -5,16 +5,16 @@ export default function map(obj, callback, thisArg) {
 
 // https://github.com/emberjs/ember.js/blob/v1.11.0/packages/ember-metal/lib/array.js
 function mapPolyfill(fun /*, thisp */) {
-  if (this === void 0 || this === null || typeof fun !== "function") {
+  if (this === void 0 || this === null || typeof fun !== 'function') {
     throw new TypeError();
   }
 
-  var t = Object(this);
-  var len = t.length >>> 0;
-  var res = new Array(len);
-  var thisp = arguments[1];
+  let t = Object(this);
+  let len = t.length >>> 0;
+  let res = new Array(len);
+  let thisp = arguments[1];
 
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     if (i in t) {
       res[i] = fun.call(thisp, t[i], i, t);
     }

--- a/app/initializers/model-fragments.js
+++ b/app/initializers/model-fragments.js
@@ -6,10 +6,10 @@ import FragmentArrayTransform from 'model-fragments/transforms/fragment-array';
 import ArrayTransform from 'model-fragments/transforms/array';
 
 export default {
-  name: "fragmentTransform",
-  before: "ember-data",
+  name: 'fragmentTransform',
+  before: 'ember-data',
 
-  initialize: function(application) {
+  initialize(application) {
     application.register('transform:fragment', FragmentTransform);
     application.register('transform:fragment-array', FragmentArrayTransform);
     application.register('transform:array', ArrayTransform);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,23 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-2-11',
+      bower: {
+        devDependencies: {
+          'ember': '~2.11.0'
+        },
+        resolutions: {
+          'ember': '~2.11.0'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source':  null,
+          'ember-data': '~2.11.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         devDependencies: {

--- a/tests/helpers/setup-ember-dev.js
+++ b/tests/helpers/setup-ember-dev.js
@@ -2,7 +2,7 @@
 //   https://github.com/emberjs/data/blob/master/tests/helpers/setup-ember-dev.js
 /* globals QUnit */
 import Ember from 'ember';
-import EmberTestHelpers from "ember-dev/test-helper/index";
+import EmberTestHelpers from 'ember-dev/test-helper/index';
 var debugModule = Ember.__loader.require('ember-metal/debug');
 
 const AVAILABLE_ASSERTIONS = ['expectAssertion', 'expectDeprecation', 'expectNoDeprecation', 'expectWarning', 'expectNoWarning'];

--- a/tests/integration/app_test.js
+++ b/tests/integration/app_test.js
@@ -3,8 +3,8 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Integration | Application');
 
-test("the model fragments initializer causes no deprecations", function(assert) {
+test('the model fragments initializer causes no deprecations', function(assert) {
   assert.expectNoDeprecation();
 
-  assert.ok(this.application.hasRegistration('transform:fragment'), "the model fragments initilizer ran");
+  assert.ok(this.application.hasRegistration('transform:fragment'), 'the model fragments initilizer ran');
 });

--- a/tests/integration/dependent_state_test.js
+++ b/tests/integration/dependent_state_test.js
@@ -3,10 +3,10 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 
-var store, people;
+let store, people;
 
-moduleForAcceptance("integration - Dependent State", {
-  beforeEach: function(assert) {
+moduleForAcceptance('integration - Dependent State', {
+  beforeEach(assert) {
     store = getOwner(this).lookup('service:store');
 
     assert.expectNoDeprecation();
@@ -15,32 +15,32 @@ moduleForAcceptance("integration - Dependent State", {
       {
         id: 1,
         name: {
-          first: "Tyrion",
-          last: "Lannister"
+          first: 'Tyrion',
+          last: 'Lannister'
         },
         addresses: [
           {
-            street: "1 Sky Cell",
-            city: "Eyre",
-            region: "Vale of Arryn",
-            country: "Westeros"
+            street: '1 Sky Cell',
+            city: 'Eyre',
+            region: 'Vale of Arryn',
+            country: 'Westeros'
           },
           {
-            street: "1 Tower of the Hand",
-            city: "King's Landing",
-            region: "Crownlands",
-            country: "Westeros"
+            street: '1 Tower of the Hand',
+            city: 'King\'s Landing',
+            region: 'Crownlands',
+            country: 'Westeros'
           }
         ],
         titles: [
-          "Hand of the King",
-          "Master of Coin"
+          'Hand of the King',
+          'Master of Coin'
         ]
       }
     ];
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
     people = null;
   }
@@ -56,7 +56,7 @@ function pushPerson(id) {
   });
 }
 
-test("changing a fragment property dirties the fragment and owner record", function(assert) {
+test('changing a fragment property dirties the fragment and owner record', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -64,25 +64,25 @@ test("changing a fragment property dirties the fragment and owner record", funct
         id: 1,
         attributes: {
           name: {
-            first: "Jamie",
-            last: "Lannister"
+            first: 'Jamie',
+            last: 'Lannister'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       name.set('first', 'Cercei');
 
-      assert.ok(name.get('hasDirtyAttributes'), "fragment is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(name.get('hasDirtyAttributes'), 'fragment is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("setting a fragment property to an object literal dirties the fragment and owner record", function(assert) {
+test('setting a fragment property to an object literal dirties the fragment and owner record', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -90,27 +90,27 @@ test("setting a fragment property to an object literal dirties the fragment and 
         id: 1,
         attributes: {
           name: {
-            first: "Visenya",
-            last: "Targaryen"
+            first: 'Visenya',
+            last: 'Targaryen'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       person.set('name', {
         first: 'Rhaenys',
       });
 
-      assert.ok(name.get('hasDirtyAttributes'), "fragment is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(name.get('hasDirtyAttributes'), 'fragment is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("setting a fragment property with an object literal to the same value does not dirty the fragment or owner record", function(assert) {
+test('setting a fragment property with an object literal to the same value does not dirty the fragment or owner record', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -118,28 +118,28 @@ test("setting a fragment property with an object literal to the same value does 
         id: 1,
         attributes: {
           name: {
-            first: "Samwell",
-            last: "Tarly"
+            first: 'Samwell',
+            last: 'Tarly'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       person.set('name', {
-        first: "Samwell",
-        last: "Tarly"
+        first: 'Samwell',
+        last: 'Tarly'
       });
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("restoring a fragment property to its original state returns the fragment and owner record to a clean state", function(assert) {
+test('restoring a fragment property to its original state returns the fragment and owner record to a clean state', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -147,26 +147,26 @@ test("restoring a fragment property to its original state returns the fragment a
         id: 1,
         attributes: {
           name: {
-            first: "Hoster",
-            last: "Tully"
+            first: 'Hoster',
+            last: 'Tully'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       name.set('first', 'Brynden');
       name.set('first', 'Hoster');
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("restoring a fragment property to its original state when the owner record was dirty returns the fragment to a clean state maintains the owner record's dirty state", function(assert) {
+test('restoring a fragment property to its original state when the owner record was dirty returns the fragment to a clean state maintains the owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -174,15 +174,15 @@ test("restoring a fragment property to its original state when the owner record 
         id: 1,
         attributes: {
           name: {
-            first: "Jorah",
-            last: "Mormont"
+            first: 'Jorah',
+            last: 'Mormont'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       // Dirty the owner record
       person.set('title', 'Lord Commander');
@@ -190,13 +190,13 @@ test("restoring a fragment property to its original state when the owner record 
       name.set('first', 'Jeor');
       name.set('first', 'Jorah');
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("rolling back the owner record returns fragment and owner record to a clean state", function(assert) {
+test('rolling back the owner record returns fragment and owner record to a clean state', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -204,27 +204,27 @@ test("rolling back the owner record returns fragment and owner record to a clean
         id: 1,
         attributes: {
           name: {
-            first: "Catelyn",
-            last: "Stark"
+            first: 'Catelyn',
+            last: 'Stark'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       name.set('last', 'Tully');
 
       person.rollbackAttributes();
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("a record can be rolled back multiple times", function(assert) {
+test('a record can be rolled back multiple times', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -232,34 +232,34 @@ test("a record can be rolled back multiple times", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Arya",
-            last: "Stark"
+            first: 'Arya',
+            last: 'Stark'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       name.set('last', '');
       person.rollbackAttributes();
 
-      assert.equal(name.get('last'), 'Stark', "fragment has correct values");
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.equal(name.get('last'), 'Stark', 'fragment has correct values');
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
 
       name.set('last', '');
       person.rollbackAttributes();
 
-      assert.equal(name.get('last'), 'Stark', "fragment has correct values");
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.equal(name.get('last'), 'Stark', 'fragment has correct values');
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("rolling back a fragment returns the fragment and the owner record to a clean state", function(assert) {
+test('rolling back a fragment returns the fragment and the owner record to a clean state', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -267,28 +267,28 @@ test("rolling back a fragment returns the fragment and the owner record to a cle
         id: 1,
         attributes: {
           name: {
-            first: "Sansa",
-            last: "Stark"
+            first: 'Sansa',
+            last: 'Stark'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       // Dirty the fragment
       name.set('last', 'Lannister');
 
       name.rollbackAttributes();
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("changing a fragment property then rolling back the owner record preserves the fragment's owner", function(assert) {
+test('changing a fragment property then rolling back the owner record preserves the fragment\'s owner', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -296,26 +296,26 @@ test("changing a fragment property then rolling back the owner record preserves 
         id: 1,
         attributes: {
           name: {
-            first: "Arya",
-            last: "Stark"
+            first: 'Arya',
+            last: 'Stark'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       person.set('name', null);
 
       person.rollbackAttributes();
 
-      assert.equal(name.get('person'), person, "fragment owner is preserved");
+      assert.equal(name.get('person'), person, 'fragment owner is preserved');
     });
   });
 });
 
-test("rolling back a fragment when the owner record is dirty returns the fragment to a clean state and maintains the owner record's dirty state", function(assert) {
+test('rolling back a fragment when the owner record is dirty returns the fragment to a clean state and maintains the owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -323,15 +323,15 @@ test("rolling back a fragment when the owner record is dirty returns the fragmen
         id: 1,
         attributes: {
           name: {
-            first: "Sansa",
-            last: "Stark"
+            first: 'Sansa',
+            last: 'Stark'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       // Dirty the owner record and fragment
       person.set('title', 'Heir to Winterfell');
@@ -339,33 +339,33 @@ test("rolling back a fragment when the owner record is dirty returns the fragmen
 
       name.rollbackAttributes();
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("a fragment property that is set to null can be rolled back", function(assert) {
+test('a fragment property that is set to null can be rolled back', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       person.set('name', null);
 
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
 
       person.rollbackAttributes();
 
-      assert.deepEqual(person.get('name'), name, "property is restored");
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.deepEqual(person.get('name'), name, 'property is restored');
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("a fragment property that is null can be rolled back", function(assert) {
+test('a fragment property that is null can be rolled back', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -375,216 +375,216 @@ test("a fragment property that is null can be rolled back", function(assert) {
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
-      assert.equal(name, undefined, "property is null");
+      assert.equal(name, undefined, 'property is null');
 
       person.set('name', store.createFragment('name', { first: 'Rob', last: 'Stark' }));
 
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
 
       person.rollbackAttributes();
 
-      assert.equal(person.get('name'), null, "property is null again");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.equal(person.get('name'), null, 'property is null again');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("changing a fragment array property with object literals dirties the fragment and owner record", function(assert) {
+test('changing a fragment array property with object literals dirties the fragment and owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       person.set('addresses', [
         {
-          street: "1 Sky Cell",
-          city: "Eyre",
-          region: "Vale of Arryn",
-          country: "Westeros"
+          street: '1 Sky Cell',
+          city: 'Eyre',
+          region: 'Vale of Arryn',
+          country: 'Westeros'
         },
         {
-          street: "1 Dungeon Cell",
-          city: "King's Landing",
-          region: "Crownlands",
-          country: "Westeros"
+          street: '1 Dungeon Cell',
+          city: 'King\'s Landing',
+          region: 'Crownlands',
+          country: 'Westeros'
         }
       ]);
 
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("adding to a fragment array property with object literals dirties the fragment and owner record", function(assert) {
+test('adding to a fragment array property with object literals dirties the fragment and owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       addresses.pushObject({
-        street: "1 Dungeon Cell",
-        city: "King's Landing",
-        region: "Crownlands",
-        country: "Westeros"
+        street: '1 Dungeon Cell',
+        city: 'King\'s Landing',
+        region: 'Crownlands',
+        country: 'Westeros'
       });
 
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("setting a fragment property with object literals to the same values does not dirty the fragment or owner record", function(assert) {
+test('setting a fragment property with object literals to the same values does not dirty the fragment or owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       person.set('addresses', people[0].addresses);
 
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("adding a fragment to a fragment array dirties the fragment array and owner record", function(assert) {
+test('adding a fragment to a fragment array dirties the fragment array and owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       addresses.createFragment('address', {
-        street: "1 Dungeon Cell",
-        city: "King's Landing",
-        region: "Crownlands",
-        country: "Westeros"
+        street: '1 Dungeon Cell',
+        city: 'King\'s Landing',
+        region: 'Crownlands',
+        country: 'Westeros'
       });
 
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("removing a fragment from a fragment array dirties the fragment array and owner record", function(assert) {
+test('removing a fragment from a fragment array dirties the fragment array and owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       addresses.removeObject(addresses.get('firstObject'));
 
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("reordering a fragment array dirties the fragment array and owner record", function(assert) {
+test('reordering a fragment array dirties the fragment array and owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var length = addresses.get('length');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let length = addresses.get('length');
 
-      var address = addresses.popObject();
+      let address = addresses.popObject();
       addresses.unshiftObject(address);
 
-      assert.equal(addresses.get('length'), length, "fragment array length is maintained");
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.equal(addresses.get('length'), length, 'fragment array length is maintained');
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("restoring a fragment array to its original order returns the fragment array owner record to a clean state", function(assert) {
+test('restoring a fragment array to its original order returns the fragment array owner record to a clean state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
-      var address = addresses.popObject();
+      let address = addresses.popObject();
       addresses.pushObject(address);
 
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("restoring a fragment array to its original order when the owner record was dirty returns the fragment array to a clean state and maintains the owner record's dirty state", function(assert) {
+test('restoring a fragment array to its original order when the owner record was dirty returns the fragment array to a clean state and maintains the owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       // Dirty the owner record
       person.set('title', 'Hand of the King');
 
-      var address = addresses.popObject();
+      let address = addresses.popObject();
       addresses.pushObject(address);
 
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("changing a fragment property in a fragment array dirties the fragment, fragment array, and owner record", function(assert) {
+test('changing a fragment property in a fragment array dirties the fragment, fragment array, and owner record', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       address.set('street', '2 Sky Cell');
 
-      assert.ok(address.get('hasDirtyAttributes'), "fragment is dirty");
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(address.get('hasDirtyAttributes'), 'fragment is dirty');
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("restoring a fragment in a fragment array property to its original state returns the fragment, fragment array, and owner record to a clean state", function(assert) {
+test('restoring a fragment in a fragment array property to its original state returns the fragment, fragment array, and owner record to a clean state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       address.set('street', '2 Sky Cell');
       address.set('street', '1 Sky Cell');
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("restoring a fragment in a fragment array property to its original state when the fragment array was dirty returns the fragment to a clean state and maintains the fragment array and owner record's dirty state", function(assert) {
+test('restoring a fragment in a fragment array property to its original state when the fragment array was dirty returns the fragment to a clean state and maintains the fragment array and owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty the record array
       addresses.popObject();
@@ -592,20 +592,20 @@ test("restoring a fragment in a fragment array property to its original state wh
       address.set('street', '2 Sky Cell');
       address.set('street', '1 Sky Cell');
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is still dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is still dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
     });
   });
 });
 
-test("restoring a fragment in a fragment array property to its original state when the owner record was dirty returns the fragment and fragment array to a clean state maintains the owner record's dirty state", function(assert) {
+test('restoring a fragment in a fragment array property to its original state when the owner record was dirty returns the fragment and fragment array to a clean state maintains the owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       address.set('street', '2 Sky Cell');
       address.set('street', '1 Sky Cell');
@@ -613,20 +613,20 @@ test("restoring a fragment in a fragment array property to its original state wh
       // Dirty the owner record
       person.set('title', 'Master of Coin');
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("rolling back the owner record returns all fragments in a fragment array property, the fragment array, and owner record to a clean state", function(assert) {
+test('rolling back the owner record returns all fragments in a fragment array property, the fragment array, and owner record to a clean state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty the owner record, fragment array, and a fragment
       person.set('title', 'Warden of the West');
@@ -635,20 +635,20 @@ test("rolling back the owner record returns all fragments in a fragment array pr
 
       person.rollbackAttributes();
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("rolling back the owner record returns all values in an array property, the array, and the owner record to a clean state", function(assert) {
+test('rolling back the owner record returns all values in an array property, the array, and the owner record to a clean state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var titles = person.get('titles');
-      var values = titles.toArray();
+    return store.find('person', 1).then(person => {
+      let titles = person.get('titles');
+      let values = titles.toArray();
 
       // Dirty the primitive array
       titles.popObject();
@@ -656,21 +656,21 @@ test("rolling back the owner record returns all values in an array property, the
 
       person.rollbackAttributes();
 
-      assert.deepEqual(values, person.get('titles').toArray(), "primitive values are reset");
-      assert.ok(!titles.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.deepEqual(values, person.get('titles').toArray(), 'primitive values are reset');
+      assert.ok(!titles.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
 
-test("rolling back a fragment array returns all fragments, the fragment array, and the owner record to a clean state", function(assert) {
+test('rolling back a fragment array returns all fragments, the fragment array, and the owner record to a clean state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty the fragment array and a fragment
       addresses.popObject();
@@ -678,20 +678,20 @@ test("rolling back a fragment array returns all fragments, the fragment array, a
 
       addresses.rollbackAttributes();
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("rolling back a fragment array when the owner record is dirty returns all fragments and the fragment array to a clean state and retain's the owner record's dirty state", function(assert) {
+test('rolling back a fragment array when the owner record is dirty returns all fragments and the fragment array to a clean state and retain\'s the owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty the owner record, fragment array, and a fragment
       person.set('title', 'Lord of the Westerlands');
@@ -700,40 +700,40 @@ test("rolling back a fragment array when the owner record is dirty returns all f
 
       addresses.rollbackAttributes();
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("rolling back a fragment in a fragment array property returns the fragment, fragment array, and owner record to a clean states", function(assert) {
+test('rolling back a fragment in a fragment array property returns the fragment, fragment array, and owner record to a clean states', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty a fragment
       address.set('street', '2 Sky Cell');
 
       address.rollbackAttributes();
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("rolling back a fragment in a fragment array property when the fragment array is dirty returns the fragment to a clean state and maintains the fragment array and owner record's dirty state", function(assert) {
+test('rolling back a fragment in a fragment array property when the fragment array is dirty returns the fragment to a clean state and maintains the fragment array and owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty fragment array, and a fragment
       addresses.popObject();
@@ -741,20 +741,20 @@ test("rolling back a fragment in a fragment array property when the fragment arr
 
       address.rollbackAttributes();
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(addresses.get('hasDirtyAttributes'), "fragment array is still dirty");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(addresses.get('hasDirtyAttributes'), 'fragment array is still dirty');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("rolling back a fragment in a fragment array property when the owner record is dirty returns the fragment and fragment array to a clean state and maintains the owner record's dirty state", function(assert) {
+test('rolling back a fragment in a fragment array property when the owner record is dirty returns the fragment and fragment array to a clean state and maintains the owner record\'s dirty state', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
       // Dirty the owner record, and a fragment
       person.set('title', 'Lord of Casterly Rock');
@@ -762,41 +762,41 @@ test("rolling back a fragment in a fragment array property when the owner record
 
       address.rollbackAttributes();
 
-      assert.ok(!address.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is still dirty");
+      assert.ok(!address.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is still dirty');
     });
   });
 });
 
-test("a fragment array property that is set to null can be rolled back", function(assert) {
+test('a fragment array property that is set to null can be rolled back', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
       person.set('addresses', null);
 
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
 
       person.rollbackAttributes();
 
-      assert.equal(person.get('addresses'), addresses, "property is restored");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.equal(person.get('addresses'), addresses, 'property is restored');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("a fragment array property that is null can be rolled back", function(assert) {
+test('a fragment array property that is null can be rolled back', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var hobbies = person.get('hobbies');
+    return store.find('person', 1).then(person => {
+      let hobbies = person.get('hobbies');
 
-      assert.equal(hobbies, null, "property is null");
+      assert.equal(hobbies, null, 'property is null');
 
       person.set('hobbies', [
         store.createFragment('hobby', {
@@ -804,17 +804,17 @@ test("a fragment array property that is null can be rolled back", function(asser
         })
       ]);
 
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
 
       person.rollbackAttributes();
 
-      assert.equal(person.get('hobbies'), null, "property is null again");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.equal(person.get('hobbies'), null, 'property is null again');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("a fragment array property that is empty can be rolled back", function(assert) {
+test('a fragment array property that is empty can be rolled back', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -824,60 +824,60 @@ test("a fragment array property that is empty can be rolled back", function(asse
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
-      assert.ok(Ember.isArray(addresses) && Ember.isEmpty(addresses), "property is an empty array");
+      assert.ok(Ember.isArray(addresses) && Ember.isEmpty(addresses), 'property is an empty array');
 
       person.set('addresses', [
         store.createFragment('address', {
-          street: "1 Spear Tower",
-          city: "Sun Spear",
-          region: "Dorne",
-          country: "Westeros"
+          street: '1 Spear Tower',
+          city: 'Sun Spear',
+          region: 'Dorne',
+          country: 'Westeros'
         })
       ]);
 
-      assert.ok(person.get('hasDirtyAttributes'), "owner record is dirty");
+      assert.ok(person.get('hasDirtyAttributes'), 'owner record is dirty');
 
       person.rollbackAttributes();
 
-      assert.ok(Ember.isArray(person.get('addresses')) && Ember.isEmpty(person.get('addresses')), "property is an empty array again");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(Ember.isArray(person.get('addresses')) && Ember.isEmpty(person.get('addresses')), 'property is an empty array again');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("pushing a fragment update doesn't cause it to become dirty", function(assert) {
+test('pushing a fragment update doesn\'t cause it to become dirty', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      assert.ok(!person.get('hasDirtyAttributes'), "person record is not dirty");
+    return store.find('person', 1).then(person => {
+      assert.ok(!person.get('hasDirtyAttributes'), 'person record is not dirty');
 
       store.push({
         data: {
           type: 'person',
           id: 1,
           attributes: {
-            name: { first: "Jamie" }
+            name: { first: 'Jamie' }
           }
         }
       });
 
-      assert.equal(person.get('name.first'), "Jamie", "first name updated");
-      assert.equal(person.get('name.last'), "Lannister", "last name is the same");
-      assert.ok(!person.get('hasDirtyAttributes'), "person record is not dirty");
+      assert.equal(person.get('name.first'), 'Jamie', 'first name updated');
+      assert.equal(person.get('name.last'), 'Lannister', 'last name is the same');
+      assert.ok(!person.get('hasDirtyAttributes'), 'person record is not dirty');
     });
   });
 });
 
-test("pushing a fragment array update doesn't cause it to become dirty", function(assert) {
+test('pushing a fragment array update doesn\'t cause it to become dirty', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      assert.ok(!person.get('hasDirtyAttributes'), "person record is not dirty");
+    return store.find('person', 1).then(person => {
+      assert.ok(!person.get('hasDirtyAttributes'), 'person record is not dirty');
 
       store.push({
         data: {
@@ -888,16 +888,16 @@ test("pushing a fragment array update doesn't cause it to become dirty", functio
               // Yeah, this is pretty weird...
               {},
               {
-                street: "1 Dungeon Cell",
+                street: '1 Dungeon Cell',
               }
             ]
           }
         }
       });
 
-      assert.equal(person.get('addresses.lastObject.street'), "1 Dungeon Cell", "street updated");
-      assert.equal(person.get('addresses.lastObject.city'), "King's Landing", "city is the same");
-      assert.ok(!person.get('hasDirtyAttributes'), "person record is not dirty");
+      assert.equal(person.get('addresses.lastObject.street'), '1 Dungeon Cell', 'street updated');
+      assert.equal(person.get('addresses.lastObject.city'), 'King\'s Landing', 'city is the same');
+      assert.ok(!person.get('hasDirtyAttributes'), 'person record is not dirty');
     });
   });
 });

--- a/tests/integration/nested_test.js
+++ b/tests/integration/nested_test.js
@@ -8,26 +8,26 @@ import Order from 'dummy/models/order';
 import Product from 'dummy/models/product';
 import Pretender from 'pretender';
 
-var store, owner, server;
+let store, owner, server;
 
-moduleForAcceptance("integration - Nested fragments", {
-  beforeEach: function(assert) {
+moduleForAcceptance('integration - Nested fragments', {
+  beforeEach(assert) {
     owner = getOwner(this);
     store = owner.lookup('service:store');
     server = new Pretender();
-    
+
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
     owner = null;
     server.shutdown();
   }
 });
 
-test("`DS.hasManyFragment` properties can be nested", function(assert) {
-  var data = {
+test('`DS.hasManyFragment` properties can be nested', function(assert) {
+  let data = {
     info: {
       name: 'Tyrion Lannister',
       notes: [ 'smart', 'short' ]
@@ -70,42 +70,42 @@ test("`DS.hasManyFragment` properties can be nested", function(assert) {
       }
     });
 
-    var payload = {
+    let payload = {
       user: Ember.copy(data, true)
     };
     payload.user.id = 1;
     payload.user.orders[0].products.splice(0, 1);
 
-    server.put('/users/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
+    server.put('/users/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
     });
 
-    return store.find('user', 1).then(function(user) {
-      assert.equal(user.get('orders.firstObject.products.firstObject.name'), 'Tears of Lys', "nested fragment array properties are converted properly");
+    return store.find('user', 1).then(user => {
+      assert.equal(user.get('orders.firstObject.products.firstObject.name'), 'Tears of Lys', 'nested fragment array properties are converted properly');
 
-      var product = user.get('orders.firstObject.products.firstObject');
+      let product = user.get('orders.firstObject.products.firstObject');
 
       product.set('price', '1.99');
-      assert.ok(user.get('hasDirtyAttributes'), "dirty state propagates to owner");
+      assert.ok(user.get('hasDirtyAttributes'), 'dirty state propagates to owner');
 
       user.rollbackAttributes();
-      assert.equal(product.get('price'), '499.99', "rollbackAttributes cascades to nested fragments");
-      assert.ok(!user.get('hasDirtyAttributes'), "dirty state is reset");
+      assert.equal(product.get('price'), '499.99', 'rollbackAttributes cascades to nested fragments');
+      assert.ok(!user.get('hasDirtyAttributes'), 'dirty state is reset');
 
       user.get('orders.firstObject.products').removeAt(0);
-      assert.ok(user.get('hasDirtyAttributes'), "dirty state propagates to owner");
+      assert.ok(user.get('hasDirtyAttributes'), 'dirty state propagates to owner');
 
       return user.save();
-    }).then(function(user) {
-      assert.ok(!user.get('hasDirtyAttributes'), "owner record is clean");
-      assert.equal(user.get('orders.firstObject.products.length'), 1, "fragment array length is correct");
+    }).then(user => {
+      assert.ok(!user.get('hasDirtyAttributes'), 'owner record is clean');
+      assert.equal(user.get('orders.firstObject.products.length'), 1, 'fragment array length is correct');
     });
   });
 });
 
-test("Fragments can be created with nested object literals", function(assert) {
-  Ember.run(function() {
-    var data = {
+test('Fragments can be created with nested object literals', function(assert) {
+  Ember.run(() => {
+    let data = {
       info: {
         name: 'Tyrion Lannister',
         notes: [ 'smart', 'short' ]
@@ -139,24 +139,24 @@ test("Fragments can be created with nested object literals", function(assert) {
       ]
     };
 
-    var user = store.createRecord('user', data);
-    var orders = user.get('orders');
+    let user = store.createRecord('user', data);
+    let orders = user.get('orders');
 
-    assert.equal(orders.get('length'), 2, "fragment array length is correct");
-    assert.ok(orders.get('firstObject') instanceof Order, "fragment instances are created");
-    assert.equal(orders.get('firstObject.amount'), data.orders[0].amount, "fragment properties are correct");
-    assert.equal(orders.get('firstObject.products.length'), 2, "nested fragment array length is correct");
-    assert.ok(orders.get('firstObject.products.firstObject') instanceof Product, "nested fragment instances are created");
-    assert.equal(orders.get('firstObject.products.firstObject.name'), data.orders[0].products[0].name, "nested fragment properties are correct");
+    assert.equal(orders.get('length'), 2, 'fragment array length is correct');
+    assert.ok(orders.get('firstObject') instanceof Order, 'fragment instances are created');
+    assert.equal(orders.get('firstObject.amount'), data.orders[0].amount, 'fragment properties are correct');
+    assert.equal(orders.get('firstObject.products.length'), 2, 'nested fragment array length is correct');
+    assert.ok(orders.get('firstObject.products.firstObject') instanceof Product, 'nested fragment instances are created');
+    assert.equal(orders.get('firstObject.products.firstObject.name'), data.orders[0].products[0].name, 'nested fragment properties are correct');
   });
 });
 
-test("Nested fragments can have default values", function(assert) {
-  Ember.run(function() {
-    var defaultInfo = {
+test('Nested fragments can have default values', function(assert) {
+  Ember.run(() => {
+    let defaultInfo = {
       notes: [ 'dangerous', 'sorry' ]
     };
-    var defaultOrders = [
+    let defaultOrders = [
       {
         amount   : '1499.99',
         products : [
@@ -169,25 +169,25 @@ test("Nested fragments can have default values", function(assert) {
       },
     ];
 
-    var Assassin = DS.Model.extend({
-      info   : MF.fragment("info", { defaultValue: defaultInfo }),
-      orders : MF.fragmentArray("order", { defaultValue: defaultOrders })
+    let Assassin = DS.Model.extend({
+      info   : MF.fragment('info', { defaultValue: defaultInfo }),
+      orders : MF.fragmentArray('order', { defaultValue: defaultOrders })
     });
 
     owner.register('model:assassin', Assassin);
 
-    var user = store.createRecord('assassin');
+    let user = store.createRecord('assassin');
 
-    assert.ok(user.get('info'), "a nested fragment is created with the default value");
-    assert.deepEqual(user.get('info.notes').toArray(), defaultInfo.notes, "a doubly nested fragment array is created with the default value");
-    assert.ok(user.get('orders.firstObject'), "a nested fragment array is created with the default value");
-    assert.equal(user.get('orders.firstObject.amount'), defaultOrders[0].amount, "a nested fragment is created with the default value");
-    assert.equal(user.get('orders.firstObject.products.firstObject.name'), defaultOrders[0].products[0].name, "a nested fragment is created with the default value");
+    assert.ok(user.get('info'), 'a nested fragment is created with the default value');
+    assert.deepEqual(user.get('info.notes').toArray(), defaultInfo.notes, 'a doubly nested fragment array is created with the default value');
+    assert.ok(user.get('orders.firstObject'), 'a nested fragment array is created with the default value');
+    assert.equal(user.get('orders.firstObject.amount'), defaultOrders[0].amount, 'a nested fragment is created with the default value');
+    assert.equal(user.get('orders.firstObject.products.firstObject.name'), defaultOrders[0].products[0].name, 'a nested fragment is created with the default value');
   });
 });
 
-test("Nested fragments can be copied", function(assert) {
-  var data = {
+test('Nested fragments can be copied', function(assert) {
+  let data = {
     info: {
       name: 'Petyr Baelish',
       notes: [ 'smart', 'despicable' ]
@@ -213,19 +213,19 @@ test("Nested fragments can be copied", function(assert) {
       }
     });
 
-    return store.find('user', 1).then(function(user) {
-      var info = user.get('info').copy();
+    return store.find('user', 1).then(user => {
+      let info = user.get('info').copy();
 
       assert.deepEqual(info.get('notes').toArray(), data.info.notes, 'nested fragment arrays are copied');
       assert.ok(info.get('notes') !== user.get('info.notes'), 'nested fragment array copies are new fragment arrays');
 
-      var orders = user.get('orders').copy();
-      var order = orders.objectAt(0);
+      let orders = user.get('orders').copy();
+      let order = orders.objectAt(0);
 
       assert.equal(order.get('recurring'), data.orders[0].recurring, 'nested fragments are copied');
       assert.ok(order !== user.get('orders.firstObject'), 'nested fragment copies are new fragments');
 
-      var product = order.get('product');
+      let product = order.get('product');
 
       assert.equal(product.get('name'), data.orders[0].product.name, 'nested fragments are copied');
       assert.ok(product !== user.get('orders.firstObject.product'), 'nested fragment copies are new fragments');
@@ -233,7 +233,7 @@ test("Nested fragments can be copied", function(assert) {
   });
 });
 
-test("Nested fragments are destroyed when the owner record is destroyed", function(assert) {
+test('Nested fragments are destroyed when the owner record is destroyed', function(assert) {
   return Ember.run(() => {
     store.push({
       data: {
@@ -260,24 +260,24 @@ test("Nested fragments are destroyed when the owner record is destroyed", functi
       }
     });
 
-    return store.find('user', 1).then(function(user) {
-      var info = user.get('info');
-      var notes = info.get('notes');
-      var orders = user.get('orders');
-      var order = orders.get('firstObject');
-      var products = order.get('products');
-      var product = products.get('firstObject');
+    return store.find('user', 1).then(user => {
+      let info = user.get('info');
+      let notes = info.get('notes');
+      let orders = user.get('orders');
+      let order = orders.get('firstObject');
+      let products = order.get('products');
+      let product = products.get('firstObject');
 
       user.destroy();
 
-      Ember.run.schedule('destroy', function() {
-        assert.ok(user.get('isDestroying'), "the user is being destroyed");
-        assert.ok(info.get('isDestroying'), "the info is being destroyed");
-        assert.ok(notes.get('isDestroying'), "the notes are being destroyed");
-        assert.ok(orders.get('isDestroying'), "the orders are being destroyed");
-        assert.ok(order.get('isDestroying'), "the order is being destroyed");
-        assert.ok(products.get('isDestroying'), "the products are being destroyed");
-        assert.ok(product.get('isDestroying'), "the product is being destroyed");
+      Ember.run.schedule('destroy', () => {
+        assert.ok(user.get('isDestroying'), 'the user is being destroyed');
+        assert.ok(info.get('isDestroying'), 'the info is being destroyed');
+        assert.ok(notes.get('isDestroying'), 'the notes are being destroyed');
+        assert.ok(orders.get('isDestroying'), 'the orders are being destroyed');
+        assert.ok(order.get('isDestroying'), 'the order is being destroyed');
+        assert.ok(products.get('isDestroying'), 'the products are being destroyed');
+        assert.ok(product.get('isDestroying'), 'the product is being destroyed');
       });
     });
   });

--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -5,10 +5,10 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 import Pretender from 'pretender';
-var store, owner, server;
+let store, owner, server;
 
-moduleForAcceptance("integration - Persistence", {
-  beforeEach: function(assert) {
+moduleForAcceptance('integration - Persistence', {
+  beforeEach(assert) {
     owner = getOwner(this);
     store = owner.lookup('service:store');
     server = new Pretender();
@@ -16,42 +16,42 @@ moduleForAcceptance("integration - Persistence", {
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
     owner = null;
     server.shutdown();
   }
 });
 
-test("persisting the owner record changes the fragment state to non-new", function(assert) {
-  var data = {
+test('persisting the owner record changes the fragment state to non-new', function(assert) {
+  let data = {
     name: {
-      first: "Viserys",
-      last: "Targaryen"
+      first: 'Viserys',
+      last: 'Targaryen'
     }
   };
 
   return Ember.run(() => {
-    var person = store.createRecord('person');
+    let person = store.createRecord('person');
 
     person.set('name', store.createFragment('name', data.name));
 
-    var payload = {
+    let payload = {
       person: Ember.copy(data, true)
     };
     payload.person.id = 3;
 
-    server.post('/people', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
+    server.post('/people', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
     });
 
-    return person.save().then(function(person) {
-      assert.ok(!person.get('name.isNew'), "fragments are not new after save");
+    return person.save().then(person => {
+      assert.ok(!person.get('name.isNew'), 'fragments are not new after save');
     });
   });
 });
 
-test("persisting the owner record in a clean state maintains clean state", function(assert) {
+test('persisting the owner record in a clean state maintains clean state', function(assert) {
   return Ember.run(() => {
     store.push({
       data: {
@@ -59,40 +59,40 @@ test("persisting the owner record in a clean state maintains clean state", funct
         id: 1,
         attributes: {
           name: {
-            first: "Tyrion",
-            last: "Lannister"
+            first: 'Tyrion',
+            last: 'Lannister'
           },
           addresses: [
             {
-              street: "1 Sky Cell",
-              city: "Eyre",
-              region: "Vale of Arryn",
-              country: "Westeros"
+              street: '1 Sky Cell',
+              city: 'Eyre',
+              region: 'Vale of Arryn',
+              country: 'Westeros'
             }
           ]
         }
       }
     });
 
-    server.put('/people/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, "{}" ];
+    server.put('/people/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, '{}' ];
     });
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       return person.save();
-    }).then(function(person) {
-      var name = person.get('name');
-      var addresses = person.get('addresses');
+    }).then(person => {
+      let name = person.get('name');
+      let addresses = person.get('addresses');
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.isAny('hasDirtyAttributes'), "all fragment array fragments are clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.isAny('hasDirtyAttributes'), 'all fragment array fragments are clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("persisting the owner record when a fragment is dirty moves owner record, fragment array, and all fragments into clean state", function(assert) {
+test('persisting the owner record when a fragment is dirty moves owner record, fragment array, and all fragments into clean state', function(assert) {
   return Ember.run(() => {
     store.push({
       data: {
@@ -100,535 +100,117 @@ test("persisting the owner record when a fragment is dirty moves owner record, f
         id: 1,
         attributes: {
           name: {
-            first: "Eddard",
-            last: "Stark"
+            first: 'Eddard',
+            last: 'Stark'
           },
           addresses: [
             {
-              street: "1 Great Keep",
-              city: "Winterfell",
-              region: "North",
-              country: "Westeros"
+              street: '1 Great Keep',
+              city: 'Winterfell',
+              region: 'North',
+              country: 'Westeros'
             }
           ]
         }
       }
     });
 
-    server.put('/people/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, "{}" ];
+    server.put('/people/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, '{}' ];
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
-      var address = person.get('addresses.firstObject');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
+      let address = person.get('addresses.firstObject');
 
       name.set('first', 'Arya');
       address.set('street', '1 Godswood');
 
       return person.save();
-    }).then(function(person) {
-      var name = person.get('name');
-      var addresses = person.get('addresses');
-      var address = addresses.get('firstObject');
+    }).then(person => {
+      let name = person.get('name');
+      let addresses = person.get('addresses');
+      let address = addresses.get('firstObject');
 
-      assert.equal(name.get('first'), 'Arya', "change is persisted");
-      assert.equal(address.get('street'), '1 Godswood', "fragment array change is persisted");
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.isAny('hasDirtyAttributes'), "all fragment array fragments are clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.equal(name.get('first'), 'Arya', 'change is persisted');
+      assert.equal(address.get('street'), '1 Godswood', 'fragment array change is persisted');
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.isAny('hasDirtyAttributes'), 'all fragment array fragments are clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("persisting a new owner record moves the owner record, fragment array, and all fragments into clean state", function(assert) {
+test('persisting a new owner record moves the owner record, fragment array, and all fragments into clean state', function(assert) {
   return Ember.run(() => {
-    var data = {
+    let data = {
       name: {
-        first: "Daenerys",
-        last: "Targaryen"
+        first: 'Daenerys',
+        last: 'Targaryen'
       },
       addresses: [
         store.createFragment('address', {
-          street: "1 Stone Drum",
-          city: "Dragonstone",
-          region: "Crownlands",
-          country: "Westeros"
+          street: '1 Stone Drum',
+          city: 'Dragonstone',
+          region: 'Crownlands',
+          country: 'Westeros'
         })
       ]
     };
 
-    var person = store.createRecord('person');
+    let person = store.createRecord('person');
     person.set('name', store.createFragment('name', data.name));
     person.set('addresses', data.addresses);
 
-    var payload = {
+    let payload = {
       person: Ember.copy(data, true)
     };
     payload.person.id = 3;
 
-    server.post('/people', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
+    server.post('/people', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
     });
 
-    return person.save().then(function(person) {
-      var name = person.get('name');
-      var addresses = person.get('addresses');
+    return person.save().then(person => {
+      let name = person.get('name');
+      let addresses = person.get('addresses');
 
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.isAny('hasDirtyAttributes'), "all fragment array fragments are clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.isAny('hasDirtyAttributes'), 'all fragment array fragments are clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("a new record can be persisted with null fragments", function(assert) {
+test('a new record can be persisted with null fragments', function(assert) {
   return Ember.run(() => {
-    var person = store.createRecord('person');
+    let person = store.createRecord('person');
 
-    assert.equal(person.get('name'), null, "fragment property is null");
-    assert.equal(person.get('hobbies'), null, "fragment array property is null");
+    assert.equal(person.get('name'), null, 'fragment property is null');
+    assert.equal(person.get('hobbies'), null, 'fragment array property is null');
 
-    var payload = {
+    let payload = {
       person: {
         id: 1
       }
     };
 
-    server.post('/people', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
+    server.post('/people', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
     });
 
-    return person.save().then(function(person) {
-      assert.equal(person.get('name'), null, "fragment property is still null");
-      assert.equal(person.get('hobbies'), null, "fragment array property is still null");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
-    });
-  });
-});
-
-test("the adapter can update fragments on save", function(assert) {
-  var data = {
-    name: {
-      first: "Eddard",
-      last: "Stark"
-    },
-    addresses: [
-      {
-        street: "1 Great Keep",
-        city: "Winterfell",
-        region: "North",
-        country: "Westeros"
-      }
-    ]
-  };
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    var payload = {
-      person: Ember.copy(data, true)
-    };
-    payload.person.id = 1;
-    payload.person.name.first = 'Ned';
-    payload.person.addresses[0].street = '1 Godswood';
-
-    server.put('/people/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
-    });
-
-    return store.find('person', 1).then(function(person) {
-      return person.save();
-    }).then(function(person) {
-      var name = person.get('name');
-      var addresses = person.get('addresses');
-
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is clean");
-      assert.ok(!addresses.isAny('hasDirtyAttributes'), "all fragment array fragments are clean");
-      assert.ok(!addresses.get('hasDirtyAttributes'), "fragment array is clean");
-      assert.ok(!person.get('hasDirtyAttributes'), "owner record is clean");
-      assert.equal(name.get('first'), 'Ned', "fragment correctly updated");
-      assert.equal(addresses.get('firstObject.street'), '1 Godswood', "fragment array fragment correctly updated");
+    return person.save().then(person => {
+      assert.equal(person.get('name'), null, 'fragment property is still null');
+      assert.equal(person.get('hobbies'), null, 'fragment array property is still null');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
     });
   });
 });
 
-test("existing fragments are updated on save", function(assert) {
-  var data = {
-    name: {
-      first: "Eddard",
-      last: "Stark"
-    },
-    addresses: [
-      {
-        street: "1 Great Keep",
-        city: "Winterfell",
-        region: "North",
-        country: "Westeros"
-      }
-    ]
-  };
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    var payload = {
-      person: Ember.copy(data, true)
-    };
-
-    payload.person.id = 1;
-    payload.person.name.first = 'Ned';
-    payload.person.addresses[0].street = '1 Godswood';
-    payload.person.addresses.unshift({
-      street: "1 Red Keep",
-      city: "Kings Landing",
-      region: "Crownlands",
-      country: "Westeros"
-    });
-
-    server.put('/people/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
-    });
-
-    var name, addresses, address;
-
-    return store.find('person', 1).then(function(person) {
-      name = person.get('name');
-      addresses = person.get('addresses');
-      address = addresses.get('firstObject');
-      return person.save();
-    }).then(function() {
-      assert.equal(name.get('first'), 'Ned', "fragment correctly updated");
-      assert.equal(address.get('street'), '1 Red Keep', "fragment array fragment correctly updated");
-      assert.equal(addresses.get('lastObject.street'), '1 Godswood', "fragment array fragment correctly updated");
-      assert.equal(addresses.get('length'), 2, "fragment array fragment correctly updated");
-    });
-  });
-});
-
-test("newly created fragments are updated on save", function(assert) {
-  var data = {
-    name: {
-      first: "Eddard",
-      last: "Stark"
-    },
-    addresses: [
-      {
-        street: "1 Great Keep",
-        city: "Winterfell",
-        region: "North",
-        country: "Westeros"
-      }
-    ]
-  };
-
-  var payload = {
-    person: Ember.copy(data, true)
-  };
-
-  payload.person.id = 1;
-  payload.person.name.first = 'Ned';
-  payload.person.addresses[0].street = '1 Godswood';
-  payload.person.addresses.unshift({
-    street: "1 Red Keep",
-    city: "Kings Landing",
-    region: "Crownlands",
-    country: "Westeros"
-  });
-
-  return Ember.run(() => {
-    server.post('/people', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
-    });
-
-    var person = store.createRecord('person');
-    var name = store.createFragment('name', Ember.copy(data.name));
-    var address = store.createFragment('address', Ember.copy(data.addresses[0]));
-
-    person.set('name', name);
-    person.set('addresses', [ address ]);
-
-    var addresses = person.get('addresses');
-
-    return person.save().then(function() {
-      assert.equal(name.get('first'), 'Ned', "fragment correctly updated");
-      assert.equal(address.get('street'), '1 Red Keep', "fragment array fragment correctly updated");
-      assert.equal(addresses.get('lastObject.street'), '1 Godswood', "fragment array fragment correctly updated");
-      assert.equal(addresses.get('length'), 2, "fragment array fragment correctly updated");
-    });
-  });
-});
-
-test("the adapter can update fragments on reload", function(assert) {
-  var data = {
-    name: {
-      first: "Brandon",
-      last: "Stark"
-    },
-    addresses: [
-      {
-        street: "1 Great Keep",
-        city: "Winterfell",
-        region: "North",
-        country: "Westeros"
-      }
-    ]
-  };
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    var payload = {
-      person: Ember.copy(data, true)
-    };
-
-    payload.person.id = 1;
-    payload.person.name.first = 'Bran';
-    payload.person.addresses[0].street = '1 Broken Tower';
-
-    server.get('/people/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
-    });
-
-    return store.find('person', 1).then(function(person) {
-      // Access values that will change to prime CP cache
-      person.get('name.first');
-      person.get('addresses.firstObject.street');
-
-      return person.reload();
-    }).then(function(person) {
-      var name = person.get('name');
-      var addresses = person.get('addresses');
-
-      assert.equal(name.get('first'), 'Bran', "fragment correctly updated");
-      assert.equal(addresses.get('firstObject.street'), '1 Broken Tower', "fragment array fragment correctly updated");
-    });
-  });
-});
-
-/*
-  Currently in certain annoying cases in Ember, including aliases or proxies that are actively observed,
-  CPs are consumed as soon as they are changed. If we are not careful, this can cause infinite loops when
-  updating existing fragment data
-*/
-test("the adapter can update fragments without infinite loops when CPs are eagerly consumed", function(assert) {
-  var data = {
-    name: {
-      first: "Brandon",
-      last: "Stark"
-    }
-  };
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    return store.find('person', 1).then(function(person) {
-      var personProxy = Ember.ObjectProxy.create({ content: person });
-
-      Ember.addObserver(personProxy, 'name.first', function() {});
-      personProxy.get('name.first');
-
-      store.push({
-        data: {
-          type: 'person',
-          id: 1,
-          attributes: data
-        }
-      });
-
-      assert.equal(person.get('name.first'), 'Brandon');
-    });
-  });
-});
-
-// TODO: The data in the adapter response is not actually changing here, which
-// means that the property actually _shouldn't_ be notified. Doing so requires
-// value diffing of deserialized model data, which means either saving a copy of
-// the data before giving it to the fragment
-test("fragment array properties are notified on save", function(assert) {
-  // The extra assertion comes from deprecation checking
-  // assert.expect(2);
-
-  var data = {
-    name: {
-      first: "Eddard",
-      last: "Stark"
-    },
-    addresses: [
-      {
-        street: "1 Great Keep",
-        city: "Winterfell",
-        region: "North",
-        country: "Westeros"
-      }
-    ]
-  };
-
-  var PersonObserver = Ember.Object.extend({
-    person: null,
-    observer: Ember.observer('person.addresses.[]', function() {
-      assert.ok(true, "The array change was observed");
-    })
-  });
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    var payload = {
-      person: Ember.copy(data, true)
-    };
-    payload.person.id = 1;
-
-    server.put('/people/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
-    });
-
-    return store.find('person', 1).then(function(person) {
-      PersonObserver.create({ person: person });
-      return person.save();
-    });
-  });
-});
-
-test("fragment array properties are notifed on reload", function(assert) {
-  // The extra assertion comes from deprecation checking
-  // assert.expect(2);
-
-  var Army = DS.Model.extend({
-    name     : DS.attr('string'),
-    soldiers : MF.array()
-  });
-
-  owner.register('model:army', Army);
-
-  var data = {
-    name: "Golden Company",
-    soldiers: [
-      "Aegor Rivers",
-      "Jon Connington",
-      "Tristan Rivers"
-    ]
-  };
-
-  var ArmyObserver = Ember.Object.extend({
-    army: null,
-    observer: Ember.observer('army.soldiers.[]', function() {
-      assert.equal(this.get('army.soldiers.length'), 2, "The array change to was observed");
-    })
-  });
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'army',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    var payload = {
-      army: Ember.copy(data, true)
-    };
-    payload.army.id = 1;
-    payload.army.soldiers.shift();
-
-    server.get('/armies/1', function() {
-      return [ 200, {"Content-Type": "application/json"}, JSON.stringify(payload) ];
-    });
-
-    return store.find('army', 1).then(function(army) {
-      ArmyObserver.create({ army: army });
-      return army.reload();
-    });
-  });
-});
-
-test('string array can be rolled back on failed save', function(assert) {
-  //assert.expect(3);
-
-  var data = {
-    name: "Golden Company",
-    soldiers: [
-      "Aegor Rivers",
-      "Jon Connington",
-      "Tristan Rivers"
-    ]
-  };
-
-  var Army = DS.Model.extend({
-    name     : DS.attr('string'),
-    soldiers : MF.array()
-  });
-
-  owner.register('model:army', Army);
-
-  return Ember.run(() => {
-    store.push({
-      data: {
-        type: 'army',
-        id: 1,
-        attributes: data
-      }
-    });
-
-    server.get('/armies', function() {
-      return [ 500, {"Content-Type": "application/json"} ];
-    });
-
-    var army, soliders;
-    return store.find('army', 1).then(function(_army) {
-      army = _army;
-      soliders = army.get('soldiers');
-      soliders.pushObject('Lysono Maar');
-      soliders.removeObject('Jon Connington');
-
-      assert.deepEqual(soliders.toArray(), ['Aegor Rivers', 'Tristan Rivers', 'Lysono Maar']);
-
-      return army.save();
-    }).catch(function() {
-      army.rollbackAttributes();
-
-      assert.deepEqual(soliders.toArray(), ['Aegor Rivers', 'Jon Connington', 'Tristan Rivers']);
-    });
-  });
-});
-
-test('existing fragments can be rolled back on failed save', function(assert) {
-  //assert.expect(3);
-
-  var data = {
+test('the adapter can update fragments on save', function(assert) {
+  let data = {
     name: {
       first: 'Eddard',
       last: 'Stark'
@@ -652,13 +234,431 @@ test('existing fragments can be rolled back on failed save', function(assert) {
       }
     });
 
-    server.put('/armies/1', function() {
-      return [ 500, {"Content-Type": "application/json"} ];
+    let payload = {
+      person: Ember.copy(data, true)
+    };
+    payload.person.id = 1;
+    payload.person.name.first = 'Ned';
+    payload.person.addresses[0].street = '1 Godswood';
+
+    server.put('/people/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
     });
 
-    var mrStark, name, address;
+    return store.find('person', 1).then(person => {
+      return person.save();
+    }).then(person => {
+      let name = person.get('name');
+      let addresses = person.get('addresses');
 
-    return store.find('person', 1).then(function(person) {
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is clean');
+      assert.ok(!addresses.isAny('hasDirtyAttributes'), 'all fragment array fragments are clean');
+      assert.ok(!addresses.get('hasDirtyAttributes'), 'fragment array is clean');
+      assert.ok(!person.get('hasDirtyAttributes'), 'owner record is clean');
+      assert.equal(name.get('first'), 'Ned', 'fragment correctly updated');
+      assert.equal(addresses.get('firstObject.street'), '1 Godswood', 'fragment array fragment correctly updated');
+    });
+  });
+});
+
+test('existing fragments are updated on save', function(assert) {
+  let data = {
+    name: {
+      first: 'Eddard',
+      last: 'Stark'
+    },
+    addresses: [
+      {
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
+      }
+    ]
+  };
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    let payload = {
+      person: Ember.copy(data, true)
+    };
+
+    payload.person.id = 1;
+    payload.person.name.first = 'Ned';
+    payload.person.addresses[0].street = '1 Godswood';
+    payload.person.addresses.unshift({
+      street: '1 Red Keep',
+      city: 'Kings Landing',
+      region: 'Crownlands',
+      country: 'Westeros'
+    });
+
+    server.put('/people/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
+    });
+
+    let name, addresses, address;
+
+    return store.find('person', 1).then(person => {
+      name = person.get('name');
+      addresses = person.get('addresses');
+      address = addresses.get('firstObject');
+      return person.save();
+    }).then(() => {
+      assert.equal(name.get('first'), 'Ned', 'fragment correctly updated');
+      assert.equal(address.get('street'), '1 Red Keep', 'fragment array fragment correctly updated');
+      assert.equal(addresses.get('lastObject.street'), '1 Godswood', 'fragment array fragment correctly updated');
+      assert.equal(addresses.get('length'), 2, 'fragment array fragment correctly updated');
+    });
+  });
+});
+
+test('newly created fragments are updated on save', function(assert) {
+  let data = {
+    name: {
+      first: 'Eddard',
+      last: 'Stark'
+    },
+    addresses: [
+      {
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
+      }
+    ]
+  };
+
+  let payload = {
+    person: Ember.copy(data, true)
+  };
+
+  payload.person.id = 1;
+  payload.person.name.first = 'Ned';
+  payload.person.addresses[0].street = '1 Godswood';
+  payload.person.addresses.unshift({
+    street: '1 Red Keep',
+    city: 'Kings Landing',
+    region: 'Crownlands',
+    country: 'Westeros'
+  });
+
+  return Ember.run(() => {
+    server.post('/people', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
+    });
+
+    let person = store.createRecord('person');
+    let name = store.createFragment('name', Ember.copy(data.name));
+    let address = store.createFragment('address', Ember.copy(data.addresses[0]));
+
+    person.set('name', name);
+    person.set('addresses', [ address ]);
+
+    let addresses = person.get('addresses');
+
+    return person.save().then(() => {
+      assert.equal(name.get('first'), 'Ned', 'fragment correctly updated');
+      assert.equal(address.get('street'), '1 Red Keep', 'fragment array fragment correctly updated');
+      assert.equal(addresses.get('lastObject.street'), '1 Godswood', 'fragment array fragment correctly updated');
+      assert.equal(addresses.get('length'), 2, 'fragment array fragment correctly updated');
+    });
+  });
+});
+
+test('the adapter can update fragments on reload', function(assert) {
+  let data = {
+    name: {
+      first: 'Brandon',
+      last: 'Stark'
+    },
+    addresses: [
+      {
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
+      }
+    ]
+  };
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    let payload = {
+      person: Ember.copy(data, true)
+    };
+
+    payload.person.id = 1;
+    payload.person.name.first = 'Bran';
+    payload.person.addresses[0].street = '1 Broken Tower';
+
+    server.get('/people/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
+    });
+
+    return store.find('person', 1).then(person => {
+      // Access values that will change to prime CP cache
+      person.get('name.first');
+      person.get('addresses.firstObject.street');
+
+      return person.reload();
+    }).then(person => {
+      let name = person.get('name');
+      let addresses = person.get('addresses');
+
+      assert.equal(name.get('first'), 'Bran', 'fragment correctly updated');
+      assert.equal(addresses.get('firstObject.street'), '1 Broken Tower', 'fragment array fragment correctly updated');
+    });
+  });
+});
+
+/*
+  Currently in certain annoying cases in Ember, including aliases or proxies that are actively observed,
+  CPs are consumed as soon as they are changed. If we are not careful, this can cause infinite loops when
+  updating existing fragment data
+*/
+test('the adapter can update fragments without infinite loops when CPs are eagerly consumed', function(assert) {
+  let data = {
+    name: {
+      first: 'Brandon',
+      last: 'Stark'
+    }
+  };
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    return store.find('person', 1).then(person => {
+      let personProxy = Ember.ObjectProxy.create({ content: person });
+
+      Ember.addObserver(personProxy, 'name.first', function() {});
+      personProxy.get('name.first');
+
+      store.push({
+        data: {
+          type: 'person',
+          id: 1,
+          attributes: data
+        }
+      });
+
+      assert.equal(person.get('name.first'), 'Brandon');
+    });
+  });
+});
+
+// TODO: The data in the adapter response is not actually changing here, which
+// means that the property actually _shouldn't_ be notified. Doing so requires
+// value diffing of deserialized model data, which means either saving a copy of
+// the data before giving it to the fragment
+test('fragment array properties are notified on save', function(assert) {
+  // The extra assertion comes from deprecation checking
+  // assert.expect(2);
+
+  let data = {
+    name: {
+      first: 'Eddard',
+      last: 'Stark'
+    },
+    addresses: [
+      {
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
+      }
+    ]
+  };
+
+  let PersonObserver = Ember.Object.extend({
+    person: null,
+    observer: Ember.observer('person.addresses.[]', function() {
+      assert.ok(true, 'The array change was observed');
+    })
+  });
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    let payload = {
+      person: Ember.copy(data, true)
+    };
+    payload.person.id = 1;
+
+    server.put('/people/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
+    });
+
+    return store.find('person', 1).then(person => {
+      PersonObserver.create({ person: person });
+      return person.save();
+    });
+  });
+});
+
+test('fragment array properties are notifed on reload', function(assert) {
+  // The extra assertion comes from deprecation checking
+  // assert.expect(2);
+
+  let Army = DS.Model.extend({
+    name     : DS.attr('string'),
+    soldiers : MF.array()
+  });
+
+  owner.register('model:army', Army);
+
+  let data = {
+    name: 'Golden Company',
+    soldiers: [
+      'Aegor Rivers',
+      'Jon Connington',
+      'Tristan Rivers'
+    ]
+  };
+
+  let ArmyObserver = Ember.Object.extend({
+    army: null,
+    observer: Ember.observer('army.soldiers.[]', function() {
+      assert.equal(this.get('army.soldiers.length'), 2, 'The array change to was observed');
+    })
+  });
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'army',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    let payload = {
+      army: Ember.copy(data, true)
+    };
+    payload.army.id = 1;
+    payload.army.soldiers.shift();
+
+    server.get('/armies/1', () => {
+      return [ 200, {'Content-Type': 'application/json'}, JSON.stringify(payload) ];
+    });
+
+    return store.find('army', 1).then(army => {
+      ArmyObserver.create({ army: army });
+      return army.reload();
+    });
+  });
+});
+
+test('string array can be rolled back on failed save', function(assert) {
+  //assert.expect(3);
+
+  let data = {
+    name: 'Golden Company',
+    soldiers: [
+      'Aegor Rivers',
+      'Jon Connington',
+      'Tristan Rivers'
+    ]
+  };
+
+  let Army = DS.Model.extend({
+    name     : DS.attr('string'),
+    soldiers : MF.array()
+  });
+
+  owner.register('model:army', Army);
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'army',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    server.get('/armies', () => {
+      return [ 500, {'Content-Type': 'application/json'} ];
+    });
+
+    let army, soliders;
+    return store.find('army', 1).then(_army => {
+      army = _army;
+      soliders = army.get('soldiers');
+      soliders.pushObject('Lysono Maar');
+      soliders.removeObject('Jon Connington');
+
+      assert.deepEqual(soliders.toArray(), ['Aegor Rivers', 'Tristan Rivers', 'Lysono Maar']);
+
+      return army.save();
+    }).catch(() => {
+      army.rollbackAttributes();
+
+      assert.deepEqual(soliders.toArray(), ['Aegor Rivers', 'Jon Connington', 'Tristan Rivers']);
+    });
+  });
+});
+
+test('existing fragments can be rolled back on failed save', function(assert) {
+  //assert.expect(3);
+
+  let data = {
+    name: {
+      first: 'Eddard',
+      last: 'Stark'
+    },
+    addresses: [
+      {
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
+      }
+    ]
+  };
+
+  return Ember.run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: data
+      }
+    });
+
+    server.put('/armies/1', () => {
+      return [ 500, {'Content-Type': 'application/json'} ];
+    });
+
+    let mrStark, name, address;
+
+    return store.find('person', 1).then(person => {
       mrStark = person;
 
       name = mrStark.get('name');
@@ -669,7 +669,7 @@ test('existing fragments can be rolled back on failed save', function(assert) {
       address.set('street', 'BadStreet');
 
       return mrStark.save();
-    }).catch(function() {
+    }).catch(() => {
       mrStark.rollbackAttributes();
 
       assert.equal(name.get('first') + ' ' + name.get('last'), 'Eddard Stark', 'fragment name rolled back');

--- a/tests/unit/array_property_test.js
+++ b/tests/unit/array_property_test.js
@@ -5,22 +5,22 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 import Person from 'dummy/models/person';
 
-var store;
+let store;
 
-moduleForAcceptance("unit - `MF.array` property", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - `MF.array` property', {
+  beforeEach(assert) {
     store = getOwner(this).lookup('service:store');
-    
+
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
   }
 });
 
-test("array properties are converted to an array-ish containing original values", function(assert) {
-  var values = [ "Hand of the King", "Master of Coin" ];
+test('array properties are converted to an array-ish containing original values', function(assert) {
+  let values = [ 'Hand of the King', 'Master of Coin' ];
 
   Ember.run(() => {
     store.push({
@@ -28,25 +28,25 @@ test("array properties are converted to an array-ish containing original values"
         type: 'person',
         id: 1,
         attributes: {
-          nickName: "Tyrion Lannister",
+          nickName: 'Tyrion Lannister',
           titles: values
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var titles = person.get('titles');
+    return store.find('person', 1).then(person => {
+      let titles = person.get('titles');
 
-      assert.ok(Ember.isArray(titles), "property is array-like");
+      assert.ok(Ember.isArray(titles), 'property is array-like');
 
-      assert.ok(titles.every(function(title, index) {
+      assert.ok(titles.every((title, index) => {
         return title === values[index];
-      }), "each title matches the original value");
+      }), 'each title matches the original value');
     });
   });
 });
 
-test("null values are allowed", function(assert) {
+test('null values are allowed', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -59,69 +59,69 @@ test("null values are allowed", function(assert) {
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      assert.equal(person.get('titles'), null, "property is null");
+    return store.find('person', 1).then(person => {
+      assert.equal(person.get('titles'), null, 'property is null');
     });
   });
 });
 
-test("setting to null is allowed", function(assert) {
+test('setting to null is allowed', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
         type: 'person',
         id: 1,
         attributes: {
-          nickName: "R'hllor",
+          nickName: 'R\'hllor',
           titles: [ 'Lord of Light', 'The Heart of Fire', 'The God of Flame and Shadow' ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.set('titles', null);
 
-      assert.equal(person.get('titles'), null, "property is null");
+      assert.equal(person.get('titles'), null, 'property is null');
     });
   });
 });
 
-test("array properties default to an empty array-ish", function(assert) {
-  Ember.run(function() {
-    var person = store.createRecord('person', {
+test('array properties default to an empty array-ish', function(assert) {
+  Ember.run(() => {
+    let person = store.createRecord('person', {
       nickName: 'Boros Blount'
     });
 
-    assert.deepEqual(person.get('titles').toArray(), [], "default value is correct");
+    assert.deepEqual(person.get('titles').toArray(), [], 'default value is correct');
   });
 });
 
-test("array properties can have default values", function(assert) {
-  Ember.run(function() {
+test('array properties can have default values', function(assert) {
+  Ember.run(() => {
     Person.reopen({
       titles: MF.array({ defaultValue: [ 'Ser' ] })
     });
 
-    var person = store.createRecord('person', {
+    let person = store.createRecord('person', {
       nickName: 'Barristan Selmy'
     });
 
-    assert.ok(person.get('titles.length'), 1, "default value length is correct");
-    assert.equal(person.get('titles.firstObject'), 'Ser', "default value is correct");
+    assert.ok(person.get('titles.length'), 1, 'default value length is correct');
+    assert.equal(person.get('titles.firstObject'), 'Ser', 'default value is correct');
   });
 });
 
-test("default values can be functions", function(assert) {
-  Ember.run(function() {
+test('default values can be functions', function(assert) {
+  Ember.run(() => {
     Person.reopen({
-      titles: MF.array({ defaultValue: function() { return [ 'Viper' ]; } })
+      titles: MF.array({ defaultValue() { return [ 'Viper' ]; } })
     });
 
-    var person = store.createRecord('person', {
+    let person = store.createRecord('person', {
       nickName: 'Oberyn Martell'
     });
 
-    assert.ok(person.get('titles.length'), 1, "default value length is correct");
-    assert.equal(person.get('titles.firstObject'), 'Viper', "default value is correct");
+    assert.ok(person.get('titles.length'), 1, 'default value length is correct');
+    assert.equal(person.get('titles.firstObject'), 'Viper', 'default value is correct');
   });
 });

--- a/tests/unit/deprecation_test.js
+++ b/tests/unit/deprecation_test.js
@@ -1,10 +1,10 @@
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 
-moduleForAcceptance("unit - Deprecations", {
-  setup: function() {
+moduleForAcceptance('unit - Deprecations', {
+  setup() {
   },
 
-  teardown: function() {
+  teardown() {
   }
 });
 

--- a/tests/unit/fragment_array_property_test.js
+++ b/tests/unit/fragment_array_property_test.js
@@ -6,11 +6,11 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 import Address from 'dummy/models/address';
 
-var owner, store, people;
-var all = Ember.RSVP.all;
+let owner, store, people;
+let all = Ember.RSVP.all;
 
-moduleForAcceptance("unit - `MF.fragmentArray` property", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - `MF.fragmentArray` property', {
+  beforeEach(assert) {
     owner = getOwner(this);
 
     store = owner.lookup('service:store');
@@ -20,43 +20,43 @@ moduleForAcceptance("unit - `MF.fragmentArray` property", {
     people = [
       {
         id: 1,
-        nickName: "Tyrion Lannister",
+        nickName: 'Tyrion Lannister',
         addresses: [
           {
-            street: "1 Sky Cell",
-            city: "Eyre",
-            region: "Vale of Arryn",
-            country: "Westeros"
+            street: '1 Sky Cell',
+            city: 'Eyre',
+            region: 'Vale of Arryn',
+            country: 'Westeros'
           },
           {
-            street: "1 Tower of the Hand",
-            city: "King's Landing",
-            region: "Crownlands",
-            country: "Westeros"
+            street: '1 Tower of the Hand',
+            city: 'King\'s Landing',
+            region: 'Crownlands',
+            country: 'Westeros'
           }
         ]
       },
       {
         id: 2,
-        nickName: "Eddard Stark",
+        nickName: 'Eddard Stark',
         addresses: [
           {
-            street: "1 Great Keep",
-            city: "Winterfell",
-            region: "North",
-            country: "Westeros"
+            street: '1 Great Keep',
+            city: 'Winterfell',
+            region: 'North',
+            country: 'Westeros'
           }
         ]
       },
       {
         id: 3,
-        nickName: "Jojen Reed",
+        nickName: 'Jojen Reed',
         addresses: null
       }
     ];
   },
 
-  teardown: function() {
+  teardown() {
     owner = null;
     store = null;
     people = null;
@@ -73,73 +73,73 @@ function pushPerson(id) {
   });
 }
 
-test("properties are instances of `MF.FragmentArray`", function(assert) {
+test('properties are instances of `MF.FragmentArray`', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
-      assert.ok(Ember.isArray(addresses), "property is array-like");
-      assert.ok(addresses instanceof MF.FragmentArray, "property is an instance of `MF.FragmentArray`");
+      assert.ok(Ember.isArray(addresses), 'property is array-like');
+      assert.ok(addresses instanceof MF.FragmentArray, 'property is an instance of `MF.FragmentArray`');
     });
   });
 });
 
-test("arrays of object literals are converted into instances of `MF.Fragment`", function(assert) {
+test('arrays of object literals are converted into instances of `MF.Fragment`', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
-      assert.ok(addresses.every(function(address) {
+      assert.ok(addresses.every(address => {
         return address instanceof Address;
-      }), "each fragment is a `MF.Fragment` instance");
+      }), 'each fragment is a `MF.Fragment` instance');
     });
   });
 });
 
-test("fragments created through the store can be added to the fragment array", function(assert) {
+test('fragments created through the store can be added to the fragment array', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var length = addresses.get('length');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let length = addresses.get('length');
 
-      var address = store.createFragment('address', {
-        street: "1 Dungeon Cell",
-        city: "King's Landing",
-        region: "Crownlands",
-        country: "Westeros"
+      let address = store.createFragment('address', {
+        street: '1 Dungeon Cell',
+        city: 'King\'s Landing',
+        region: 'Crownlands',
+        country: 'Westeros'
       });
 
       addresses.addFragment(address);
 
-      assert.equal(addresses.get('length'), length + 1, "address property size is correct");
-      assert.equal(addresses.indexOf(address), length, "new fragment is in correct location");
+      assert.equal(addresses.get('length'), length + 1, 'address property size is correct');
+      assert.equal(addresses.indexOf(address), length, 'new fragment is in correct location');
     });
   });
 });
 
-test("adding a non-fragment model or object literal throws an error", function(assert) {
+test('adding a non-fragment model or object literal throws an error', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
-      assert.throws(function() {
-        var otherPerson = store.createRecord('person');
+      assert.throws(() => {
+        let otherPerson = store.createRecord('person');
 
         addresses.addFragment(otherPerson);
-      }, "error is thrown when adding a DS.Model instance");
+      }, 'error is thrown when adding a DS.Model instance');
     });
   });
 });
 
-test("adding fragments from other records throws an error", function(assert) {
+test('adding fragments from other records throws an error', function(assert) {
   Ember.run(() => {
     pushPerson(1);
     pushPerson(2);
@@ -147,40 +147,40 @@ test("adding fragments from other records throws an error", function(assert) {
     return all([
       store.find('person', 1),
       store.find('person', 2)
-    ]).then(function(people) {
-      var address = people[0].get('addresses.firstObject');
+    ]).then(people => {
+      let address = people[0].get('addresses.firstObject');
 
-      assert.throws(function() {
+      assert.throws(() => {
         people[1].get('addresses').addFragment(address);
-      }, "error is thrown when adding a fragment from another record");
+      }, 'error is thrown when adding a fragment from another record');
     });
   });
 });
 
-test("setting to an array of fragments is allowed", function(assert) {
+test('setting to an array of fragments is allowed', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
 
-      var address = store.createFragment('address', {
-        street: "1 Dungeon Cell",
-        city: "King's Landing",
-        region: "Crownlands",
-        country: "Westeros"
+      let address = store.createFragment('address', {
+        street: '1 Dungeon Cell',
+        city: 'King\'s Landing',
+        region: 'Crownlands',
+        country: 'Westeros'
       });
 
       person.set('addresses', [ address ]);
 
-      assert.equal(person.get('addresses'), addresses, "fragment array is the same object");
-      assert.equal(person.get('addresses.length'), 1, "fragment array has the correct length");
-      assert.equal(person.get('addresses.firstObject'), address, "fragment array contains the new fragment");
+      assert.equal(person.get('addresses'), addresses, 'fragment array is the same object');
+      assert.equal(person.get('addresses.length'), 1, 'fragment array has the correct length');
+      assert.equal(person.get('addresses.firstObject'), address, 'fragment array contains the new fragment');
     });
   });
 });
 
-test("defaults to an empty array", function(assert) {
+test('defaults to an empty array', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -198,68 +198,68 @@ test("defaults to an empty array", function(assert) {
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      assert.ok(Ember.isArray(person.get('addresses')), "defaults to an array");
-      assert.ok(Ember.isEmpty(person.get('addresses')), "default array is empty");
+    return store.find('person', 1).then(person => {
+      assert.ok(Ember.isArray(person.get('addresses')), 'defaults to an array');
+      assert.ok(Ember.isEmpty(person.get('addresses')), 'default array is empty');
 
-      store.find('person', 2).then(function(person2) {
-        assert.ok(person.get('addresses') !== person2.get('addresses'), "default array is unique");
+      store.find('person', 2).then(person2 => {
+        assert.ok(person.get('addresses') !== person2.get('addresses'), 'default array is unique');
       });
     });
   });
 });
 
-test("default value can be null", function(assert) {
+test('default value can be null', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      assert.equal(person.get('hobbies'), null, "defaults to null");
+    return store.find('person', 1).then(person => {
+      assert.equal(person.get('hobbies'), null, 'defaults to null');
 
-      var hobbies = [
+      let hobbies = [
         store.createFragment('hobby', {
           name: 'guitar'
         })
       ];
 
       person.set('hobbies', hobbies);
-      assert.equal(person.get('hobbies.length'), 1, "can be set to an array");
+      assert.equal(person.get('hobbies.length'), 1, 'can be set to an array');
     });
   });
 });
 
-test("null values are allowed", function(assert) {
+test('null values are allowed', function(assert) {
   Ember.run(() => {
     pushPerson(3);
 
-    return store.find('person', 3).then(function(person) {
-      assert.equal(person.get('addresses'), null, "property is null");
+    return store.find('person', 3).then(person => {
+      assert.equal(person.get('addresses'), null, 'property is null');
     });
   });
 });
 
-test("setting to null is allowed", function(assert) {
+test('setting to null is allowed', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.set('addresses', null);
 
-      assert.equal(person.get('addresses'), null, "property is null");
+      assert.equal(person.get('addresses'), null, 'property is null');
     });
   });
 });
 
-test("fragments are created from an array of object literals when creating a record", function(assert) {
-  Ember.run(function() {
-    var address = {
+test('fragments are created from an array of object literals when creating a record', function(assert) {
+  Ember.run(() => {
+    let address = {
       street: '1 Sea Tower',
       city: 'Pyke',
       region: 'Iron Islands',
       country: 'Westeros'
     };
 
-    var person = store.createRecord('person', {
+    let person = store.createRecord('person', {
       name: {
         first: 'Balon',
         last: 'Greyjoy'
@@ -267,13 +267,13 @@ test("fragments are created from an array of object literals when creating a rec
       addresses: [ address ]
     });
 
-    assert.ok(person.get('addresses.firstObject') instanceof MF.Fragment, "a `MF.Fragment` instance is created");
-    assert.equal(person.get('addresses.firstObject.street'), address.street, "fragment has correct values");
+    assert.ok(person.get('addresses.firstObject') instanceof MF.Fragment, 'a `MF.Fragment` instance is created');
+    assert.equal(person.get('addresses.firstObject.street'), address.street, 'fragment has correct values');
   });
 });
 
-test("setting a fragment array to an array of to an object literals creates new fragments", function(assert) {
-  var address = {
+test('setting a fragment array to an array of to an object literals creates new fragments', function(assert) {
+  let address = {
     street: '1 Great Keep',
     city: 'Pyke',
     region: 'Iron Islands',
@@ -295,17 +295,17 @@ test("setting a fragment array to an array of to an object literals creates new 
       }
     });
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.set('addresses', [ address ]);
 
-      assert.ok(person.get('addresses.firstObject') instanceof MF.Fragment, "a `MF.Fragment` instance is created");
-      assert.equal(person.get('addresses.firstObject.street'), address.street, "fragment has correct values");
+      assert.ok(person.get('addresses.firstObject') instanceof MF.Fragment, 'a `MF.Fragment` instance is created');
+      assert.equal(person.get('addresses.firstObject.street'), address.street, 'fragment has correct values');
     });
   });
 });
 
-test("setting a fragment array to an array of object literals reuses an existing fragments", function(assert) {
-  var newAddress = {
+test('setting a fragment array to an array of object literals reuses an existing fragments', function(assert) {
+  let newAddress = {
     street: '1 Great Keep',
     city: 'Winterfell',
     region: 'North',
@@ -334,123 +334,123 @@ test("setting a fragment array to an array of object literals reuses an existing
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var address = person.get('addresses.firstObject');
+    return store.find('person', 1).then(person => {
+      let address = person.get('addresses.firstObject');
 
       person.set('addresses', [ newAddress ]);
 
-      assert.equal(address, person.get('addresses.firstObject'), "fragment instances are reused");
-      assert.equal(person.get('addresses.firstObject.street'), newAddress.street, "fragment has correct values");
+      assert.equal(address, person.get('addresses.firstObject'), 'fragment instances are reused');
+      assert.equal(person.get('addresses.firstObject.street'), newAddress.street, 'fragment has correct values');
     });
   });
 });
 
 
-test("setting to an array of non-fragments throws an error", function(assert) {
+test('setting to an array of non-fragments throws an error', function(assert) {
   Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      assert.throws(function() {
+    return store.find('person', 1).then(person => {
+      assert.throws(() => {
         person.set('addresses', [ 'address' ]);
-      }, "error is thrown when setting to an array of non-fragments");
+      }, 'error is thrown when setting to an array of non-fragments');
     });
   });
 });
 
-test("fragments can have default values", function(assert) {
-  Ember.run(function() {
-    var defaultValue = [
+test('fragments can have default values', function(assert) {
+  Ember.run(() => {
+    let defaultValue = [
       {
-        street: "1 Throne Room",
-        city: "King's Landing",
-        region: "Crownlands",
-        country: "Westeros"
+        street: '1 Throne Room',
+        city: 'King\'s Landing',
+        region: 'Crownlands',
+        country: 'Westeros'
       }
     ];
 
-    var Throne = DS.Model.extend({
+    let Throne = DS.Model.extend({
       name: DS.attr('string'),
       addresses: MF.fragmentArray('address', { defaultValue: defaultValue })
     });
 
     owner.register('model:throne', Throne);
 
-    var throne = store.createRecord('throne', { name: 'Iron' });
+    let throne = store.createRecord('throne', { name: 'Iron' });
 
-    assert.equal(throne.get('addresses.firstObject.street'), defaultValue[0].street, "the default value is used when the value has not been specified");
+    assert.equal(throne.get('addresses.firstObject.street'), defaultValue[0].street, 'the default value is used when the value has not been specified');
 
     throne.set('addresses', null);
-    assert.equal(throne.get('addresses'), null, "the default value is not used when the value is set to null");
+    assert.equal(throne.get('addresses'), null, 'the default value is not used when the value is set to null');
 
     throne = store.createRecord('throne', { name: 'Iron', addresses: null });
-    assert.equal(throne.get('addresses'), null, "the default value is not used when the value is initialized to null");
+    assert.equal(throne.get('addresses'), null, 'the default value is not used when the value is initialized to null');
   });
 });
 
-test("fragment default values can be functions", function(assert) {
-  Ember.run(function() {
-    var defaultValue = [
+test('fragment default values can be functions', function(assert) {
+  Ember.run(() => {
+    let defaultValue = [
       {
-        street: "1 Great Keep",
-        city: "Winterfell",
-        region: "North",
-        country: "Westeros"
+        street: '1 Great Keep',
+        city: 'Winterfell',
+        region: 'North',
+        country: 'Westeros'
       }
     ];
 
-    var Sword = DS.Model.extend({
+    let Sword = DS.Model.extend({
       name: DS.attr('string'),
-      addresses: MF.fragmentArray('address', { defaultValue: function() { return defaultValue; } })
+      addresses: MF.fragmentArray('address', { defaultValue() { return defaultValue; } })
     });
 
     owner.register('model:sword', Sword);
 
-    var sword = store.createRecord('sword', { name: 'Ice' });
+    let sword = store.createRecord('sword', { name: 'Ice' });
 
-    assert.equal(sword.get('addresses.firstObject.street'), defaultValue[0].street, "the default value is correct");
+    assert.equal(sword.get('addresses.firstObject.street'), defaultValue[0].street, 'the default value is correct');
   });
 });
 
-test("destroy a fragment array which was set to null", function(assert) {
+test('destroy a fragment array which was set to null', function(assert) {
   return Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var firstAddress = addresses.objectAt(0);
-      var secondAddress = addresses.objectAt(1);
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let firstAddress = addresses.objectAt(0);
+      let secondAddress = addresses.objectAt(1);
       person.set('addresses', null);
 
       person.destroy();
 
-      Ember.run.schedule('destroy', function() {
-        assert.ok(person.get('isDestroying'), "the model is being destroyed");
-        assert.ok(addresses.get('isDestroying'), "the fragment array is being destroyed");
-        assert.ok(firstAddress.get('isDestroying'), "the first fragment is being destroyed");
-        assert.ok(secondAddress.get('isDestroying'), "the second fragment is being destroyed");
+      Ember.run.schedule('destroy', () => {
+        assert.ok(person.get('isDestroying'), 'the model is being destroyed');
+        assert.ok(addresses.get('isDestroying'), 'the fragment array is being destroyed');
+        assert.ok(firstAddress.get('isDestroying'), 'the first fragment is being destroyed');
+        assert.ok(secondAddress.get('isDestroying'), 'the second fragment is being destroyed');
       });
     });
   });
 });
 
-test("destroy a fragment which was removed from the fragment array", function(assert) {
+test('destroy a fragment which was removed from the fragment array', function(assert) {
   return Ember.run(() => {
     pushPerson(1);
 
-    return store.find('person', 1).then(function(person) {
-      var addresses = person.get('addresses');
-      var firstAddress = addresses.objectAt(0);
-      var secondAddress = addresses.objectAt(1);
+    return store.find('person', 1).then(person => {
+      let addresses = person.get('addresses');
+      let firstAddress = addresses.objectAt(0);
+      let secondAddress = addresses.objectAt(1);
       addresses.removeAt(0);
 
       person.destroy();
 
-      Ember.run.schedule('destroy', function() {
-        assert.ok(person.get('isDestroying'), "the model is being destroyed");
-        assert.ok(addresses.get('isDestroying'), "the fragment array is being destroyed");
-        assert.ok(firstAddress.get('isDestroying'), "the removed fragment is being destroyed");
-        assert.ok(secondAddress.get('isDestroying'), "the remaining fragment is being destroyed");
+      Ember.run.schedule('destroy', () => {
+        assert.ok(person.get('isDestroying'), 'the model is being destroyed');
+        assert.ok(addresses.get('isDestroying'), 'the fragment array is being destroyed');
+        assert.ok(firstAddress.get('isDestroying'), 'the removed fragment is being destroyed');
+        assert.ok(secondAddress.get('isDestroying'), 'the remaining fragment is being destroyed');
       });
     });
   });

--- a/tests/unit/fragment_array_test.js
+++ b/tests/unit/fragment_array_test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
-var store;
+let store;
 
 // `contains` was deprecated in Ember 2.8. Replaced with `includes`.
 // Use `includes` when possible because if using >= ember-2-8, `contains` will produce a deprecation.
@@ -10,24 +10,24 @@ function includes(array, item) {
   return array.includes ? array.includes(item) : array.contains(item);
 }
 
-moduleForAcceptance("unit - `MF.fragmentArray`", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - `MF.fragmentArray`', {
+  beforeEach(assert) {
     store = getOwner(this).lookup('service:store');
 
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
   }
 });
 
-test("fragment arrays can be copied", function(assert) {
-  var data = {
+test('fragment arrays can be copied', function(assert) {
+  let data = {
     names: [
       {
-        first: "Meryn",
-        last: "Trant"
+        first: 'Meryn',
+        last: 'Trant'
       }
     ]
   };
@@ -41,17 +41,17 @@ test("fragment arrays can be copied", function(assert) {
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var copy = person.get('names').copy();
+    return store.find('person', 1).then(person => {
+      let copy = person.get('names').copy();
 
-      assert.equal(copy.length, person.get('names.length'), "copy's size is correct");
-      assert.equal(copy[0].get('first'), data.names[0].first, "child fragments are copied");
-      assert.ok(copy[0] !== person.get('names.firstObject'), "copied fragments are new fragments");
+      assert.equal(copy.length, person.get('names.length'), 'copy\'s size is correct');
+      assert.equal(copy[0].get('first'), data.names[0].first, 'child fragments are copied');
+      assert.ok(copy[0] !== person.get('names.firstObject'), 'copied fragments are new fragments');
     });
   });
 });
 
-test("fragments can be created and added through the fragment array", function(assert) {
+test('fragments can be created and added through the fragment array', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -60,30 +60,30 @@ test("fragments can be created and added through the fragment array", function(a
         attributes: {
           names: [
             {
-              first: "Tyrion",
-              last: "Lannister"
+              first: 'Tyrion',
+              last: 'Lannister'
             }
           ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var fragments = person.get('names');
-      var length = fragments.get('length');
+    return store.find('person', 1).then(person => {
+      let fragments = person.get('names');
+      let length = fragments.get('length');
 
-      var fragment = fragments.createFragment({
-        first: "Hugor",
-        last: "Hill"
+      let fragment = fragments.createFragment({
+        first: 'Hugor',
+        last: 'Hill'
       });
 
-      assert.equal(fragments.get('length'), length + 1, "property size is correct");
-      assert.equal(fragments.indexOf(fragment), length, "new fragment is in correct location");
+      assert.equal(fragments.get('length'), length + 1, 'property size is correct');
+      assert.equal(fragments.indexOf(fragment), length, 'new fragment is in correct location');
     });
   });
 });
 
-test("fragments can be added to the fragment array", function(assert) {
+test('fragments can be added to the fragment array', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -92,31 +92,31 @@ test("fragments can be added to the fragment array", function(assert) {
         attributes: {
           names: [
             {
-              first: "Tyrion",
-              last: "Lannister"
+              first: 'Tyrion',
+              last: 'Lannister'
             }
           ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var fragments = person.get('names');
-      var length = fragments.get('length');
+    return store.find('person', 1).then(person => {
+      let fragments = person.get('names');
+      let length = fragments.get('length');
 
-      var fragment = store.createFragment('name', {
-        first: "Yollo"
+      let fragment = store.createFragment('name', {
+        first: 'Yollo'
       });
 
       fragments.addFragment(fragment);
 
-      assert.equal(fragments.get('length'), length + 1, "property size is correct");
-      assert.equal(fragments.indexOf(fragment), length, "fragment is in correct location");
+      assert.equal(fragments.get('length'), length + 1, 'property size is correct');
+      assert.equal(fragments.indexOf(fragment), length, 'fragment is in correct location');
     });
   });
 });
 
-test("fragments can be removed from the fragment array", function(assert) {
+test('fragments can be removed from the fragment array', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -125,28 +125,28 @@ test("fragments can be removed from the fragment array", function(assert) {
         attributes: {
           names: [
             {
-              first: "Arya",
-              last: "Stark"
+              first: 'Arya',
+              last: 'Stark'
             }
           ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var fragments = person.get('names');
-      var fragment = fragments.get('firstObject');
-      var length = fragments.get('length');
+    return store.find('person', 1).then(person => {
+      let fragments = person.get('names');
+      let fragment = fragments.get('firstObject');
+      let length = fragments.get('length');
 
       fragments.removeFragment(fragment);
 
-      assert.equal(fragments.get('length'), length - 1, "property size is correct");
-      assert.ok(!includes(fragments, fragment), "fragment is removed");
+      assert.equal(fragments.get('length'), length - 1, 'property size is correct');
+      assert.ok(!includes(fragments, fragment), 'fragment is removed');
     });
   });
 });
 
-test("changes to array contents change the fragment array 'hasDirtyAttributes' property", function(assert) {
+test('changes to array contents change the fragment array `hasDirtyAttributes` property', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -155,58 +155,58 @@ test("changes to array contents change the fragment array 'hasDirtyAttributes' p
         attributes: {
           names: [
             {
-              first: "Aegon",
-              last: "Targaryen"
+              first: 'Aegon',
+              last: 'Targaryen'
             },
             {
-              first: "Visenya",
-              last: "Targaryen"
+              first: 'Visenya',
+              last: 'Targaryen'
             }
           ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var fragments = person.get('names');
-      var fragment = fragments.get('firstObject');
-      var newFragment = store.createFragment('name', {
+    return store.find('person', 1).then(person => {
+      let fragments = person.get('names');
+      let fragment = fragments.get('firstObject');
+      let newFragment = store.createFragment('name', {
         first: 'Rhaenys',
         last: 'Targaryen'
       });
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is initially in a clean state");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is initially in a clean state');
 
       fragments.removeFragment(fragment);
 
-      assert.ok(fragments.get('hasDirtyAttributes'), "fragment array is in dirty state after removal");
+      assert.ok(fragments.get('hasDirtyAttributes'), 'fragment array is in dirty state after removal');
 
       fragments.unshiftObject(fragment);
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is returned to clean state");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is returned to clean state');
 
       fragments.addFragment(newFragment);
 
-      assert.ok(fragments.get('hasDirtyAttributes'), "fragment array is in dirty state after addition");
+      assert.ok(fragments.get('hasDirtyAttributes'), 'fragment array is in dirty state after addition');
 
       fragments.removeFragment(newFragment);
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is returned to clean state");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is returned to clean state');
 
       fragments.removeFragment(fragment);
       fragments.addFragment(fragment);
 
-      assert.ok(fragments.get('hasDirtyAttributes'), "fragment array is in dirty state after reordering");
+      assert.ok(fragments.get('hasDirtyAttributes'), 'fragment array is in dirty state after reordering');
 
       fragments.removeFragment(fragment);
       fragments.unshiftObject(fragment);
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is returned to clean state");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is returned to clean state');
     });
   });
 });
 
-test("changes to array contents change the fragment array 'hasDirtyAttributes' property", function(assert) {
+test('changes to array contents change the fragment array `hasDirtyAttributes` property', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -215,32 +215,32 @@ test("changes to array contents change the fragment array 'hasDirtyAttributes' p
         attributes: {
           names: [
             {
-              first: "Jon",
-              last: "Snow"
+              first: 'Jon',
+              last: 'Snow'
             }
           ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var fragments = person.get('names');
-      var fragment = fragments.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let fragments = person.get('names');
+      let fragment = fragments.get('firstObject');
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is initially in a clean state");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is initially in a clean state');
 
       fragment.set('last', 'Stark');
 
-      assert.ok(fragments.get('hasDirtyAttributes'), "fragment array in dirty state after change to a fragment");
+      assert.ok(fragments.get('hasDirtyAttributes'), 'fragment array in dirty state after change to a fragment');
 
       fragment.set('last', 'Snow');
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is returned to clean state");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is returned to clean state');
     });
   });
 });
 
-test("changes to array contents and fragments can be rolled back", function(assert) {
+test('changes to array contents and fragments can be rolled back', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -249,23 +249,23 @@ test("changes to array contents and fragments can be rolled back", function(asse
         attributes: {
           names: [
             {
-              first: "Catelyn",
-              last: "Tully"
+              first: 'Catelyn',
+              last: 'Tully'
             },
             {
-              first: "Catelyn",
-              last: "Stark"
+              first: 'Catelyn',
+              last: 'Stark'
             }
           ]
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var fragments = person.get('names');
-      var fragment = fragments.get('firstObject');
+    return store.find('person', 1).then(person => {
+      let fragments = person.get('names');
+      let fragment = fragments.get('firstObject');
 
-      var originalState = fragments.toArray();
+      let originalState = fragments.toArray();
 
       fragment.set('first', 'Cat');
       fragments.removeFragment(fragments.get('lastObject'));
@@ -276,9 +276,9 @@ test("changes to array contents and fragments can be rolled back", function(asse
 
       fragments.rollbackAttributes();
 
-      assert.ok(!fragments.get('hasDirtyAttributes'), "fragment array is not dirty");
-      assert.ok(!fragments.isAny('hasDirtyAttributes'), "all fragments are in clean state");
-      assert.deepEqual(fragments.toArray(), originalState, "original array contents is restored");
+      assert.ok(!fragments.get('hasDirtyAttributes'), 'fragment array is not dirty');
+      assert.ok(!fragments.isAny('hasDirtyAttributes'), 'all fragments are in clean state');
+      assert.deepEqual(fragments.toArray(), originalState, 'original array contents is restored');
     });
   });
 });

--- a/tests/unit/fragment_owner_property_test.js
+++ b/tests/unit/fragment_owner_property_test.js
@@ -5,24 +5,24 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 
-var store, owner;
-var all = Ember.RSVP.all;
+let store, owner;
+let all = Ember.RSVP.all;
 
-moduleForAcceptance("unit - `MF.fragmentOwner` property", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - `MF.fragmentOwner` property', {
+  beforeEach(assert) {
     owner = getOwner(this);
     store = owner.lookup('service:store');
-    
+
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     owner = null;
     store = null;
   }
 });
 
-test("fragments can reference their owner record", function(assert) {
+test('fragments can reference their owner record', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -30,38 +30,38 @@ test("fragments can reference their owner record", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Samwell",
-            last: "Tarly"
+            first: 'Samwell',
+            last: 'Tarly'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
-      assert.equal(name.get('person'), person, "fragment owner property is reference to the owner record");
+      assert.equal(name.get('person'), person, 'fragment owner property is reference to the owner record');
     });
   });
 });
 
-test("using a fragment owner property on a non-fragment throws an error", function(assert) {
-  Ember.run(function() {
-    var InvalidModel = DS.Model.extend({
+test('using a fragment owner property on a non-fragment throws an error', function(assert) {
+  Ember.run(() => {
+    let InvalidModel = DS.Model.extend({
       owner: MF.fragmentOwner()
     });
 
     owner.register('model:invalidModel', InvalidModel);
 
-    var invalid = store.createRecord('invalidModel');
+    let invalid = store.createRecord('invalidModel');
 
-    assert.throws(function() {
+    assert.throws(() => {
       invalid.get('owner');
-    }, /Fragment owner properties can only be used on fragments/, "getting fragment owner on non-fragment throws an error");
+    }, /Fragment owner properties can only be used on fragments/, 'getting fragment owner on non-fragment throws an error');
   });
 });
 
-test("attempting to change a fragment's owner record throws an error", function(assert) {
+test('attempting to change a fragment\'s owner record throws an error', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -69,8 +69,8 @@ test("attempting to change a fragment's owner record throws an error", function(
         id: 1,
         attributes: {
           name: {
-            first: "Samwell",
-            last: "Tarly"
+            first: 'Samwell',
+            last: 'Tarly'
           }
         }
       }
@@ -82,8 +82,8 @@ test("attempting to change a fragment's owner record throws an error", function(
         id: 2,
         attributes: {
           name: {
-            first: "Samwell",
-            last: "Tarly"
+            first: 'Samwell',
+            last: 'Tarly'
           }
         }
       }
@@ -92,17 +92,17 @@ test("attempting to change a fragment's owner record throws an error", function(
     return all([
       store.find('person', 1),
       store.find('person', 2)
-    ]).then(function(people) {
-      var name = people[0].get('name');
+    ]).then(people => {
+      let name = people[0].get('name');
 
-      assert.throws(function() {
+      assert.throws(() => {
         name.set('person', people[1]);
-      }, "setting the owner property throws an error");
+      }, 'setting the owner property throws an error');
     });
   });
 });
 
-test("fragment owner properties are notified of change", function(assert) {
+test('fragment owner properties are notified of change', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -110,24 +110,24 @@ test("fragment owner properties are notified of change", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Jeyne",
-            last: "Poole"
+            first: 'Jeyne',
+            last: 'Poole'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = store.createFragment('name', {
+    return store.find('person', 1).then(person => {
+      let name = store.createFragment('name', {
         first: 'Arya',
         last: 'Stark'
       });
 
-      assert.ok(!name.get('person'), "fragment owner property is null");
+      assert.ok(!name.get('person'), 'fragment owner property is null');
 
       person.set('name', name);
 
-      assert.equal(name.get('person'), person, "fragment owner property is updated");
+      assert.equal(name.get('person'), person, 'fragment owner property is updated');
     });
   });
 });

--- a/tests/unit/fragment_property_test.js
+++ b/tests/unit/fragment_property_test.js
@@ -6,24 +6,24 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 import Name from 'dummy/models/name';
 
-var store, owner;
-var all = Ember.RSVP.all;
+let store, owner;
+let all = Ember.RSVP.all;
 
-moduleForAcceptance("unit - `MF.fragment` property", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - `MF.fragment` property', {
+  beforeEach(assert) {
     owner = getOwner(this);
     store = owner.lookup('service:store');
-    
+
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     owner = null;
     store = null;
   }
 });
 
-test("object literals are converted to instances of `MF.Fragment`", function(assert) {
+test('object literals are converted to instances of `MF.Fragment`', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -31,22 +31,22 @@ test("object literals are converted to instances of `MF.Fragment`", function(ass
         id: 1,
         attributes: {
           name: {
-            first: "Tyrion",
-            last: "Lannister"
+            first: 'Tyrion',
+            last: 'Lannister'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      assert.ok(person.get('name') instanceof Name, "name property is an `MF.Fragment` instance");
+    return store.find('person', 1).then(person => {
+      assert.ok(person.get('name') instanceof Name, 'name property is an `MF.Fragment` instance');
 
-      assert.equal(person.get('name.first'), 'Tyrion', "nested properties have original value");
+      assert.equal(person.get('name.first'), 'Tyrion', 'nested properties have original value');
     });
   });
 });
 
-test("a fragment can be created through the store and set", function(assert) {
+test('a fragment can be created through the store and set', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -56,20 +56,20 @@ test("a fragment can be created through the store and set", function(assert) {
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = store.createFragment('name', {
-        first: "Davos",
-        last: "Seaworth"
+    return store.find('person', 1).then(person => {
+      let name = store.createFragment('name', {
+        first: 'Davos',
+        last: 'Seaworth'
       });
 
       person.set('name', name);
 
-      assert.equal(person.get('name.first'), 'Davos', "new fragment is correctly set");
+      assert.equal(person.get('name.first'), 'Davos', 'new fragment is correctly set');
     });
   });
 });
 
-test("setting to a non-fragment or object literal throws an error", function(assert) {
+test('setting to a non-fragment or object literal throws an error', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -79,15 +79,15 @@ test("setting to a non-fragment or object literal throws an error", function(ass
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      assert.throws(function() {
+    return store.find('person', 1).then(person => {
+      assert.throws(() => {
         person.set('name', store.createRecord('person'));
-      }, "error is thrown when setting non-fragment");
+      }, 'error is thrown when setting non-fragment');
     });
   });
 });
 
-test("setting fragments from other records throws an error", function(assert) {
+test('setting fragments from other records throws an error', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -95,8 +95,8 @@ test("setting fragments from other records throws an error", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Roose",
-            last: "Bolton"
+            first: 'Roose',
+            last: 'Bolton'
           }
         }
       }
@@ -113,15 +113,15 @@ test("setting fragments from other records throws an error", function(assert) {
     return all([
       store.find('person', 1),
       store.find('person', 2)
-    ]).then(function(people) {
-      assert.throws(function() {
+    ]).then(people => {
+      assert.throws(() => {
         people[1].set('name', people[0].get('name'));
-      }, "error is thrown when setting to a fragment of another record");
+      }, 'error is thrown when setting to a fragment of another record');
     });
   });
 });
 
-test("null values are allowed", function(assert) {
+test('null values are allowed', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -133,13 +133,13 @@ test("null values are allowed", function(assert) {
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      assert.equal(person.get('name'), null, "property is null");
+    return store.find('person', 1).then(person => {
+      assert.equal(person.get('name'), null, 'property is null');
     });
   });
 });
 
-test("setting to null is allowed", function(assert) {
+test('setting to null is allowed', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -147,38 +147,38 @@ test("setting to null is allowed", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Barristan",
-            last: "Selmy"
+            first: 'Barristan',
+            last: 'Selmy'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.set('name', null);
-      assert.equal(person.get('name'), null, "property is null");
+      assert.equal(person.get('name'), null, 'property is null');
     });
   });
 });
 
-test("fragments are created from object literals when creating a record", function(assert) {
+test('fragments are created from object literals when creating a record', function(assert) {
   Ember.run(() => {
-    var name = {
+    let name = {
       first: 'Balon',
       last: 'Greyjoy'
     };
 
-    var person = store.createRecord('person', {
+    let person = store.createRecord('person', {
       name: name
     });
 
-    assert.ok(person.get('name') instanceof MF.Fragment, "a `MF.Fragment` instance is created");
-    assert.equal(person.get('name.first'), name.first, "fragment has correct values");
+    assert.ok(person.get('name') instanceof MF.Fragment, 'a `MF.Fragment` instance is created');
+    assert.equal(person.get('name.first'), name.first, 'fragment has correct values');
   });
 });
 
-test("setting a fragment to an object literal creates a new fragment", function(assert) {
-  var name = {
+test('setting a fragment to an object literal creates a new fragment', function(assert) {
+  let name = {
     first: 'Asha',
     last: 'Greyjoy'
   };
@@ -194,17 +194,17 @@ test("setting a fragment to an object literal creates a new fragment", function(
       }
     });
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.set('name', name);
 
-      assert.ok(person.get('name') instanceof MF.Fragment, "a `MF.Fragment` instance is created");
-      assert.equal(person.get('name.first'), name.first, "fragment has correct values");
+      assert.ok(person.get('name') instanceof MF.Fragment, 'a `MF.Fragment` instance is created');
+      assert.equal(person.get('name.first'), name.first, 'fragment has correct values');
     });
   });
 });
 
-test("setting a fragment to an object literal reuses an existing fragment", function(assert) {
-  var newName = {
+test('setting a fragment to an object literal reuses an existing fragment', function(assert) {
+  let newName = {
     first: 'Reek',
     last: null
   };
@@ -223,62 +223,62 @@ test("setting a fragment to an object literal reuses an existing fragment", func
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       person.set('name', newName);
 
-      assert.equal(name, person.get('name'), "fragment instances are reused");
-      assert.equal(person.get('name.first'), newName.first, "fragment has correct values");
+      assert.equal(name, person.get('name'), 'fragment instances are reused');
+      assert.equal(person.get('name.first'), newName.first, 'fragment has correct values');
     });
   });
 });
 
-test("fragments can have default values", function(assert) {
+test('fragments can have default values', function(assert) {
   Ember.run(() => {
-    var defaultValue = {
-      first: "Iron",
-      last: "Victory"
+    let defaultValue = {
+      first: 'Iron',
+      last: 'Victory'
     };
 
-    var Ship = DS.Model.extend({
-      name: MF.fragment("name", { defaultValue: defaultValue }),
+    let Ship = DS.Model.extend({
+      name: MF.fragment('name', { defaultValue: defaultValue }),
     });
 
     owner.register('model:ship', Ship);
 
-    var ship = store.createRecord('ship');
+    let ship = store.createRecord('ship');
 
-    assert.equal(ship.get('name.first'), defaultValue.first, "the default value is used when the value has not been specified");
+    assert.equal(ship.get('name.first'), defaultValue.first, 'the default value is used when the value has not been specified');
 
     ship.set('name', null);
-    assert.equal(ship.get('name'), null, "the default value is not used when the value is set to null");
+    assert.equal(ship.get('name'), null, 'the default value is not used when the value is set to null');
 
     ship = store.createRecord('ship', { name: null });
-    assert.equal(ship.get('name'), null, "the default value is not used when the value is initialized to null");
+    assert.equal(ship.get('name'), null, 'the default value is not used when the value is initialized to null');
   });
 });
 
-test("fragment default values can be functions", function(assert) {
+test('fragment default values can be functions', function(assert) {
   Ember.run(() => {
-    var defaultValue = {
-      first: "Oath",
-      last: "Keeper"
+    let defaultValue = {
+      first: 'Oath',
+      last: 'Keeper'
     };
 
-    var Sword = DS.Model.extend({
-      name: MF.fragment("name", { defaultValue: function() { return defaultValue; } }),
+    let Sword = DS.Model.extend({
+      name: MF.fragment('name', { defaultValue() { return defaultValue; } }),
     });
 
     owner.register('model:sword', Sword);
 
-    var sword = store.createRecord('sword');
+    let sword = store.createRecord('sword');
 
-    assert.equal(sword.get('name.first'), defaultValue.first, "the default value is correct");
+    assert.equal(sword.get('name.first'), defaultValue.first, 'the default value is correct');
   });
 });
 
-test("destroy a fragment which was set to null", function(assert) {
+test('destroy a fragment which was set to null', function(assert) {
   return Ember.run(() => {
     store.push({
       data: {
@@ -286,28 +286,28 @@ test("destroy a fragment which was set to null", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Barristan",
-            last: "Selmy"
+            first: 'Barristan',
+            last: 'Selmy'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
       person.set('name', null);
 
       person.destroy();
 
-      Ember.run.schedule('destroy', function() {
-        assert.ok(person.get('isDestroying'), "the model is being destroyed");
-        assert.ok(name.get('isDestroying'), "the fragment is being destroyed");
+      Ember.run.schedule('destroy', () => {
+        assert.ok(person.get('isDestroying'), 'the model is being destroyed');
+        assert.ok(name.get('isDestroying'), 'the fragment is being destroyed');
       });
     });
   });
 });
 
-test("destroy the old and new fragment value", function(assert) {
+test('destroy the old and new fragment value', function(assert) {
   return Ember.run(() => {
     store.push({
       data: {
@@ -315,26 +315,26 @@ test("destroy the old and new fragment value", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Barristan",
-            last: "Selmy"
+            first: 'Barristan',
+            last: 'Selmy'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var oldName = person.get('name');
-      var newName = store.createFragment('name');
+    return store.find('person', 1).then(person => {
+      let oldName = person.get('name');
+      let newName = store.createFragment('name');
       person.set('name', newName);
 
-      assert.ok(!oldName.get('isDestroying'), "don't destroy the old fragment yet because we could rollback");
+      assert.ok(!oldName.get('isDestroying'), 'don\'t destroy the old fragment yet because we could rollback');
 
       person.destroy();
 
-      Ember.run.schedule('destroy', function() {
-        assert.ok(person.get('isDestroying'), "the model is being destroyed");
-        assert.ok(oldName.get('isDestroying'), "the old fragment is being destroyed");
-        assert.ok(newName.get('isDestroying'), "the new fragment is being destroyed");
+      Ember.run.schedule('destroy', () => {
+        assert.ok(person.get('isDestroying'), 'the model is being destroyed');
+        assert.ok(oldName.get('isDestroying'), 'the old fragment is being destroyed');
+        assert.ok(newName.get('isDestroying'), 'the new fragment is being destroyed');
       });
     });
   });

--- a/tests/unit/fragment_test.js
+++ b/tests/unit/fragment_test.js
@@ -3,28 +3,28 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 
-var store;
-var all = Ember.RSVP.all;
+let store;
+let all = Ember.RSVP.all;
 
-moduleForAcceptance("unit - `MF.Fragment`", {
-  beforeEach: function() {
+moduleForAcceptance('unit - `MF.Fragment`', {
+  beforeEach() {
     store = getOwner(this).lookup('service:store');
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
   }
 });
 
-test("fragments are `Ember.Copyable`", function(assert) {
+test('fragments are `Ember.Copyable`', function(assert) {
   Ember.run(() => {
-    var fragment = store.createFragment('name');
+    let fragment = store.createFragment('name');
 
-    assert.ok(Ember.Copyable.detect(fragment), "fragments are copyable");
+    assert.ok(Ember.Copyable.detect(fragment), 'fragments are copyable');
   });
 });
 
-test("copied fragments can be added to any record", function(assert) {
+test('copied fragments can be added to any record', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -32,8 +32,8 @@ test("copied fragments can be added to any record", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Jon",
-            last: "Snow"
+            first: 'Jon',
+            last: 'Snow'
           }
         }
       }
@@ -50,17 +50,17 @@ test("copied fragments can be added to any record", function(assert) {
     return all([
       store.find('person', 1),
       store.find('person', 2)
-    ]).then(function(people) {
-      var copy = people[0].get('name').copy();
+    ]).then(people => {
+      let copy = people[0].get('name').copy();
 
       people[1].set('name', copy);
 
-      assert.ok(true, "fragment copies can be assigned to other records");
+      assert.ok(true, 'fragment copies can be assigned to other records');
     });
   });
 });
 
-test("copying a fragment copies the fragment's properties", function(assert) {
+test('copying a fragment copies the fragment\'s properties', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -68,55 +68,55 @@ test("copying a fragment copies the fragment's properties", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Jon",
-            last: "Snow"
+            first: 'Jon',
+            last: 'Snow'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var copy = person.get('name').copy();
+    return store.find('person', 1).then(person => {
+      let copy = person.get('name').copy();
 
-      assert.ok(copy.get('first'), "Jon");
-      assert.ok(copy.get('last'), "Snow");
+      assert.ok(copy.get('first'), 'Jon');
+      assert.ok(copy.get('last'), 'Snow');
     });
   });
 });
 
-test("fragments are `Ember.Comparable`", function(assert) {
+test('fragments are `Ember.Comparable`', function(assert) {
   Ember.run(() => {
-    var fragment = store.createFragment('name');
+    let fragment = store.createFragment('name');
 
-    assert.ok(Ember.Comparable.detect(fragment), "fragments are comparable");
+    assert.ok(Ember.Comparable.detect(fragment), 'fragments are comparable');
   });
 });
 
-test("fragments are compared by reference", function(assert) {
+test('fragments are compared by reference', function(assert) {
   Ember.run(() => {
-    var fragment1 = store.createFragment('name', {
-      first: "Jon",
-      last: "Arryn"
+    let fragment1 = store.createFragment('name', {
+      first: 'Jon',
+      last: 'Arryn'
     });
-    var fragment2 = store.createFragment('name', {
-      first: "Jon",
-      last: "Arryn"
+    let fragment2 = store.createFragment('name', {
+      first: 'Jon',
+      last: 'Arryn'
     });
 
-    assert.ok(fragment1.compare(fragment1, fragment2) !== 0, "deeply equal objects are not the same");
-    assert.ok(fragment1.compare(fragment1, fragment1) === 0, "identical objects are the same");
+    assert.ok(fragment1.compare(fragment1, fragment2) !== 0, 'deeply equal objects are not the same');
+    assert.ok(fragment1.compare(fragment1, fragment1) === 0, 'identical objects are the same');
   });
 });
 
-test("newly create fragments start in the new state", function(assert) {
+test('newly create fragments start in the new state', function(assert) {
   Ember.run(() => {
-    var fragment = store.createFragment('name');
+    let fragment = store.createFragment('name');
 
-    assert.ok(fragment.get('isNew'), "fragments start as new");
+    assert.ok(fragment.get('isNew'), 'fragments start as new');
   });
 });
 
-test("changes to fragments are indicated in the owner record's `changedAttributes`", function(assert) {
+test('changes to fragments are indicated in the owner record\'s `changedAttributes`', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -124,24 +124,24 @@ test("changes to fragments are indicated in the owner record's `changedAttribute
         id: 1,
         attributes: {
           name: {
-            first: "Loras",
-            last: "Tyrell"
+            first: 'Loras',
+            last: 'Tyrell'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       name.set('last', 'Baratheon');
 
-      assert.equal(person.changedAttributes().name, true, "changed fragments are indicated in the diff object");
+      assert.equal(person.changedAttributes().name, true, 'changed fragments are indicated in the diff object');
     });
   });
 });
 
-test("fragment properties that are set to null are indicated in the owner record's `changedAttributes`", function(assert) {
+test('fragment properties that are set to null are indicated in the owner record\'s `changedAttributes`', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -149,22 +149,22 @@ test("fragment properties that are set to null are indicated in the owner record
         id: 1,
         attributes: {
           name: {
-            first: "Rob",
-            last: "Stark"
+            first: 'Rob',
+            last: 'Stark'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.set('name', null);
 
-      assert.equal(person.changedAttributes().name, true, "null fragments are indicated in the diff object");
+      assert.equal(person.changedAttributes().name, true, 'null fragments are indicated in the diff object');
     });
   });
 });
 
-test("changes to attributes can be rolled back", function(assert) {
+test('changes to attributes can be rolled back', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -172,29 +172,29 @@ test("changes to attributes can be rolled back", function(assert) {
         id: 1,
         attributes: {
           name: {
-            first: "Ramsay",
-            last: "Snow"
+            first: 'Ramsay',
+            last: 'Snow'
           }
         }
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var name = person.get('name');
+    return store.find('person', 1).then(person => {
+      let name = person.get('name');
 
       name.set('last', 'Bolton');
       name.rollbackAttributes();
 
-      assert.ok(name.get('last', 'Snow'), "fragment properties are restored");
-      assert.ok(!name.get('hasDirtyAttributes'), "fragment is in clean state");
+      assert.ok(name.get('last', 'Snow'), 'fragment properties are restored');
+      assert.ok(!name.get('hasDirtyAttributes'), 'fragment is in clean state');
     });
   });
 });
 
-test("fragments without an owner can be destroyed", function(assert) {
+test('fragments without an owner can be destroyed', function(assert) {
   Ember.run(() => {
-    var fragment = store.createFragment('name');
+    let fragment = store.createFragment('name');
     fragment.destroy();
-    assert.ok(fragment.get('isDestroying'), "the fragment is being destroyed");
+    assert.ok(fragment.get('isDestroying'), 'the fragment is being destroyed');
   });
 });

--- a/tests/unit/polymorphic_test.js
+++ b/tests/unit/polymorphic_test.js
@@ -5,10 +5,10 @@ import getOwner from '../helpers/get-owner';
 import Animal from 'dummy/models/animal';
 import Lion from 'dummy/models/lion';
 import Elephant from 'dummy/models/elephant';
-var store, zoo;
+let store, zoo;
 
-moduleForAcceptance("unit - Polymorphism", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - Polymorphism', {
+  beforeEach(assert) {
     store = getOwner(this).lookup('service:store');
 
     assert.expectNoDeprecation();
@@ -36,12 +36,12 @@ moduleForAcceptance("unit - Polymorphism", {
     };
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
   }
 });
 
-test("fragment properties support polymorphism", function(assert) {
+test('fragment properties support polymorphism', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -51,20 +51,20 @@ test("fragment properties support polymorphism", function(assert) {
       }
     });
 
-    return store.find('zoo', 1).then(function(zoo) {
-      assert.equal(zoo.get("name"), "Chilly Zoo", "zoo name is correct");
-      assert.equal(zoo.get("city"), "Winterfell", "zoo city is correct");
+    return store.find('zoo', 1).then(zoo => {
+      assert.equal(zoo.get('name'), 'Chilly Zoo', 'zoo name is correct');
+      assert.equal(zoo.get('city'), 'Winterfell', 'zoo city is correct');
 
-      var star = zoo.get("star");
-      assert.ok(star instanceof Animal, "zoo's star is an animal");
-      assert.equal(star.get("name"), "Mittens", "animal name is correct");
-      assert.ok(star instanceof Lion, "zoo's star is a lion");
-      assert.ok(star.get("hasManes"), "lion has manes");
+      let star = zoo.get('star');
+      assert.ok(star instanceof Animal, 'zoo\'s star is an animal');
+      assert.equal(star.get('name'), 'Mittens', 'animal name is correct');
+      assert.ok(star instanceof Lion, 'zoo\'s star is a lion');
+      assert.ok(star.get('hasManes'), 'lion has manes');
     });
   });
 });
 
-test("fragment array properties support polymorphism", function(assert) {
+test('fragment array properties support polymorphism', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -74,27 +74,27 @@ test("fragment array properties support polymorphism", function(assert) {
       }
     });
 
-    return store.find('zoo', 1).then(function(zoo) {
-      var animals = zoo.get("animals");
-      assert.equal(animals.get("length"), 2);
+    return store.find('zoo', 1).then(zoo => {
+      let animals = zoo.get('animals');
+      assert.equal(animals.get('length'), 2);
 
-      var first = animals.objectAt(0);
+      let first = animals.objectAt(0);
       assert.ok(first instanceof Animal);
-      assert.equal(first.get("name"), "Mittens", "first animal's name is correct");
+      assert.equal(first.get('name'), 'Mittens', 'first animal\'s name is correct');
       assert.ok(first instanceof Lion);
-      assert.ok(first.get("hasManes"), "lion has manes");
+      assert.ok(first.get('hasManes'), 'lion has manes');
 
-      var second = animals.objectAt(1);
+      let second = animals.objectAt(1);
       assert.ok(second instanceof Animal);
-      assert.equal(second.get("name"), "Snuitje", "second animal's name is correct");
+      assert.equal(second.get('name'), 'Snuitje', 'second animal\'s name is correct');
       assert.ok(second instanceof Elephant);
-      assert.equal(second.get("trunkLength"), 4, "elephant's trunk length is correct");
+      assert.equal(second.get('trunkLength'), 4, 'elephant\'s trunk length is correct');
     });
   });
 });
 
-test("fragment property type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled", function(assert) {
-  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+test('fragment property type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled', function(assert) {
+  let injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
   Ember.MODEL_FACTORY_INJECTIONS = true;
 
   try {
@@ -108,7 +108,7 @@ test("fragment property type-checks check the superclass when MODEL_FACTORY_INJE
       });
 
       zoo = store.createRecord('zoo', { name: 'The World' });
-      var animal = store.createFragment('elephant', { name: 'Mr. Pink' });
+      let animal = store.createFragment('elephant', { name: 'Mr. Pink' });
 
       zoo.set('star', animal);
 
@@ -119,7 +119,7 @@ test("fragment property type-checks check the superclass when MODEL_FACTORY_INJE
   }
 });
 
-test("rolling back a fragment property that was set to null checks the superclass when MODEL_FACTORY_INJECTIONS is enabled", function(assert) {
+test('rolling back a fragment property that was set to null checks the superclass when MODEL_FACTORY_INJECTIONS is enabled', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -129,30 +129,30 @@ test("rolling back a fragment property that was set to null checks the superclas
       }
     });
 
-    var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+    let injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
     Ember.MODEL_FACTORY_INJECTIONS = true;
 
-    return store.find('zoo', 1).then(function(zoo) {
-      var animal = zoo.get('star');
+    return store.find('zoo', 1).then(zoo => {
+      let animal = zoo.get('star');
 
       zoo.set('star', null);
       zoo.rollbackAttributes();
 
       assert.equal(zoo.get('star.name'), animal.get('name'), 'The type check succeeded');
-    }).finally(function() {
+    }).finally(() => {
       Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
     });
   });
 });
 
-test("fragment array property type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled", function(assert) {
-  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+test('fragment array property type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled', function(assert) {
+  let injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
   Ember.MODEL_FACTORY_INJECTIONS = true;
 
   try {
     Ember.run(() => {
-      var zoo = store.createRecord('zoo', { name: 'The World' });
-      var animal = store.createFragment('elephant', { name: 'Whitey' });
+      let zoo = store.createRecord('zoo', { name: 'The World' });
+      let animal = store.createFragment('elephant', { name: 'Whitey' });
 
       zoo.get('animals').pushObject(animal);
 

--- a/tests/unit/serialize_test.js
+++ b/tests/unit/serialize_test.js
@@ -6,10 +6,10 @@ import JSONSerializer from 'ember-data/serializers/json';
 import Person from 'dummy/models/person';
 import MF from 'model-fragments';
 import DS from 'ember-data';
-var store, owner;
+let store, owner;
 
-moduleForAcceptance("unit - Serialization", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - Serialization', {
+  beforeEach(assert) {
     owner = getOwner(this);
     store = owner.lookup('service:store');
 
@@ -19,27 +19,27 @@ moduleForAcceptance("unit - Serialization", {
     store.modelFor('person');
   },
 
-  afterEach: function() {
+  afterEach() {
     owner = null;
     store = null;
   }
 });
 
-test("fragment properties are snapshotted as normal attributes on the owner record snapshot", function(assert) {
-  var person = {
+test('fragment properties are snapshotted as normal attributes on the owner record snapshot', function(assert) {
+  let person = {
     name: {
-      first : "Catelyn",
-      last  : "Stark"
+      first : 'Catelyn',
+      last  : 'Stark'
     },
     houses: [
       {
-        name   : "Tully",
-        region : "Riverlands",
+        name   : 'Tully',
+        region : 'Riverlands',
         exiled : true
       },
       {
-        name   : "Stark",
-        region : "North",
+        name   : 'Stark',
+        region : 'North',
         exiled : true
       }
     ],
@@ -62,29 +62,29 @@ test("fragment properties are snapshotted as normal attributes on the owner reco
     });
 
     owner.register('serializer:person', JSONSerializer.extend({
-      serialize: function(snapshot) {
-        var name = snapshot.attr('name');
-        assert.ok(name instanceof DS.Snapshot, "fragment snapshot attribute is a snapshot");
-        assert.equal(name.attr('first'), person.name.first, "fragment attributes are snapshoted correctly");
+      serialize(snapshot) {
+        let name = snapshot.attr('name');
+        assert.ok(name instanceof DS.Snapshot, 'fragment snapshot attribute is a snapshot');
+        assert.equal(name.attr('first'), person.name.first, 'fragment attributes are snapshoted correctly');
 
-        var houses = snapshot.attr('houses');
-        assert.ok(Array.isArray(houses), "fragment array attribute is an array");
-        assert.ok(houses[0] instanceof DS.Snapshot, "fragment array attribute is an array of snapshots");
-        assert.equal(houses[0].attr('name'), person.houses[0].name, "fragment array attributes are snapshotted correctly");
+        let houses = snapshot.attr('houses');
+        assert.ok(Array.isArray(houses), 'fragment array attribute is an array');
+        assert.ok(houses[0] instanceof DS.Snapshot, 'fragment array attribute is an array of snapshots');
+        assert.equal(houses[0].attr('name'), person.houses[0].name, 'fragment array attributes are snapshotted correctly');
 
-        var children = snapshot.attr('children');
-        assert.ok(Array.isArray(children), "array attribute is an array");
-        assert.deepEqual(children, person.children, "array attribute is snapshotted correctly");
+        let children = snapshot.attr('children');
+        assert.ok(Array.isArray(children), 'array attribute is an array');
+        assert.deepEqual(children, person.children, 'array attribute is snapshotted correctly');
       }
     }));
 
-    return store.find('person', 1).then(function(person) {
+    return store.find('person', 1).then(person => {
       person.serialize();
     });
   });
 });
 
-test("fragment properties are serialized as normal attributes using their own serializers", function(assert) {
+test('fragment properties are serialized as normal attributes using their own serializers', function(assert) {
   Ember.run(() => {
     store.push({
       data: {
@@ -92,40 +92,40 @@ test("fragment properties are serialized as normal attributes using their own se
         id: 1,
         attributes: {
           name: {
-            first: "Aerys",
-            last: "Targaryen"
+            first: 'Aerys',
+            last: 'Targaryen'
           }
         }
       }
     });
 
     owner.register('serializer:name', JSONSerializer.extend({
-      serialize: function() {
+      serialize() {
         return 'Mad King';
       }
     }));
 
-    return store.find('person', 1).then(function(person) {
-      var serialized = person.serialize();
+    return store.find('person', 1).then(person => {
+      let serialized = person.serialize();
 
-      assert.equal(serialized.name, 'Mad King', "serialization uses result from `fragment#serialize`");
+      assert.equal(serialized.name, 'Mad King', 'serialization uses result from `fragment#serialize`');
     });
   });
 });
 
-test("serializing a fragment array creates a new array with contents the result of serializing each fragment", function(assert) {
-  var names = [
+test('serializing a fragment array creates a new array with contents the result of serializing each fragment', function(assert) {
+  let names = [
     {
-      first: "Rhaegar",
-      last: "Targaryen"
+      first: 'Rhaegar',
+      last: 'Targaryen'
     },
     {
-      first: "Viserys",
-      last: "Targaryen"
+      first: 'Viserys',
+      last: 'Targaryen'
     },
     {
-      first: "Daenerys",
-      last: "Targaryen"
+      first: 'Daenerys',
+      last: 'Targaryen'
     }
   ];
 
@@ -142,37 +142,37 @@ test("serializing a fragment array creates a new array with contents the result 
 
     owner.register('serializer:name', JSONSerializer);
 
-    return store.find('person', 1).then(function(person) {
-      var serialized = person.serialize();
+    return store.find('person', 1).then(person => {
+      let serialized = person.serialize();
 
-      assert.deepEqual(serialized.names, names, "serializing returns array of each fragment serialized");
+      assert.deepEqual(serialized.names, names, 'serializing returns array of each fragment serialized');
     });
   });
 });
 
-test("normalizing data can handle `null` fragment values", function(assert) {
-  var NullDefaultPerson = Person.extend({
+test('normalizing data can handle `null` fragment values', function(assert) {
+  let NullDefaultPerson = Person.extend({
     houses: MF.fragmentArray('house', { defaultValue: null }),
     children: MF.array({ defaultValue: null })
   });
 
   owner.register('model:nullDefaultPerson', NullDefaultPerson);
 
-  var normalized = store.normalize('nullDefaultPerson', {
+  let normalized = store.normalize('nullDefaultPerson', {
     name: null,
     houses: null,
     children: null
   });
 
-  var attributes = normalized.data.attributes;
+  let attributes = normalized.data.attributes;
 
-  assert.strictEqual(attributes.name, null, "fragment property values can be null");
-  assert.strictEqual(attributes.houses, null, "fragment array property values can be null");
-  assert.strictEqual(attributes.children, null, "`array property values can be null");
+  assert.strictEqual(attributes.name, null, 'fragment property values can be null');
+  assert.strictEqual(attributes.houses, null, 'fragment array property values can be null');
+  assert.strictEqual(attributes.children, null, '`array property values can be null');
 });
 
-test("normalizing data can handle `null` fragment values", function(assert) {
-  var NullDefaultPerson = Person.extend({
+test('normalizing data can handle `null` fragment values', function(assert) {
+  let NullDefaultPerson = Person.extend({
     houses: MF.fragmentArray('house', { defaultValue: null }),
     children: MF.array({ defaultValue: null })
   });
@@ -192,36 +192,36 @@ test("normalizing data can handle `null` fragment values", function(assert) {
       }
     });
 
-    return store.find('nullDefaultPerson', 1).then(function(person) {
-      var serialized = person.serialize();
+    return store.find('nullDefaultPerson', 1).then(person => {
+      let serialized = person.serialize();
 
-      assert.strictEqual(serialized.name, null, "fragment property values can be null");
-      assert.strictEqual(serialized.houses, null, "fragment array property values can be null");
-      assert.strictEqual(serialized.children, null, "`array property values can be null");
+      assert.strictEqual(serialized.name, null, 'fragment property values can be null');
+      assert.strictEqual(serialized.houses, null, 'fragment array property values can be null');
+      assert.strictEqual(serialized.children, null, '`array property values can be null');
     });
   });
 });
 
-test("array properties use the specified transform to normalize data", function(assert) {
-  var values = [ 1, 0, true, false, 'true', '' ];
+test('array properties use the specified transform to normalize data', function(assert) {
+  let values = [ 1, 0, true, false, 'true', '' ];
 
-  var normalized = store.normalize('person', {
+  let normalized = store.normalize('person', {
     strings: values,
     numbers: values,
     booleans: values
   });
 
-  var attributes = normalized.data.attributes;
+  let attributes = normalized.data.attributes;
 
-  assert.ok(values.every(function(value, index) {
+  assert.ok(values.every((value, index) => {
     return attributes.strings[index] === String(value) &&
       attributes.numbers[index] === (Ember.isEmpty(value) || isNaN(Number(value)) ? null : Number(value)) &&
       attributes.booleans[index] === Boolean(value);
-  }), "fragment property values are normalized");
+  }), 'fragment property values are normalized');
 });
 
-test("array properties use the specified transform to serialize data", function(assert) {
-  var values = [ 1, 0, true, false, 'true', '' ];
+test('array properties use the specified transform to serialize data', function(assert) {
+  let values = [ 1, 0, true, false, 'true', '' ];
 
   Ember.run(() => {
     store.push({
@@ -236,14 +236,14 @@ test("array properties use the specified transform to serialize data", function(
       }
     });
 
-    return store.find('person', 1).then(function(person) {
-      var serialized = person.serialize();
+    return store.find('person', 1).then(person => {
+      let serialized = person.serialize();
 
-      assert.ok(values.every(function(value, index) {
+      assert.ok(values.every((value, index) => {
         return serialized.strings[index] === String(value) &&
           serialized.numbers[index] === (Ember.isEmpty(value) || isNaN(Number(value)) ? null : Number(value)) &&
           serialized.booleans[index] === Boolean(value);
-      }), "fragment property values are normalized");
+      }), 'fragment property values are normalized');
     });
   });
 });

--- a/tests/unit/store_test.js
+++ b/tests/unit/store_test.js
@@ -5,89 +5,89 @@ import getOwner from '../helpers/get-owner';
 import Name from 'dummy/models/name';
 import JSONAPISerializer from 'ember-data/serializers/json-api';
 import JSONSerializer from 'ember-data/serializers/json';
-var store, owner;
+let store, owner;
 
-moduleForAcceptance("unit - `DS.Store`", {
-  beforeEach: function(assert) {
+moduleForAcceptance('unit - `DS.Store`', {
+  beforeEach(assert) {
     owner = getOwner(this);
     store = owner.lookup('service:store');
 
     assert.expectNoDeprecation();
   },
 
-  afterEach: function() {
+  afterEach() {
     store = null;
     owner = null;
   }
 });
 
-test("a fragment can be created that starts in a dirty state", function(assert) {
+test('a fragment can be created that starts in a dirty state', function(assert) {
   Ember.run(() => {
-    var address = store.createFragment('name');
+    let address = store.createFragment('name');
 
-    assert.ok(address instanceof Name, "fragment is correct type");
-    assert.ok(address.get('hasDirtyAttributes'), "fragment starts in dirty state");
+    assert.ok(address instanceof Name, 'fragment is correct type');
+    assert.ok(address.get('hasDirtyAttributes'), 'fragment starts in dirty state');
   });
 });
 
-test("attempting to create a fragment type that does not inherit from `MF.Fragment` throws an error", function(assert) {
+test('attempting to create a fragment type that does not inherit from `MF.Fragment` throws an error', function(assert) {
   Ember.run(() => {
-    assert.throws(function() {
+    assert.throws(() => {
       store.createFragment('person');
-    }, "an error is thrown when given a bad type");
+    }, 'an error is thrown when given a bad type');
   });
 });
 
-test("the store has an `isFragment` method", function(assert) {
+test('the store has an `isFragment` method', function(assert) {
   assert.ok(store.isFragment('name'), 'a fragment should return true');
   assert.notOk(store.isFragment('person', 'a model should return false'));
 });
 
-test("the default fragment serializer does not use the application serializer", function(assert) {
-  var Serializer = JSONAPISerializer.extend();
+test('the default fragment serializer does not use the application serializer', function(assert) {
+  let Serializer = JSONAPISerializer.extend();
   owner.register('serializer:application', Serializer);
 
-  assert.ok(!(store.serializerFor('name') instanceof Serializer), "fragment serializer fallback is not `JSONAPISerializer`");
-  assert.ok(store.serializerFor('name') instanceof JSONSerializer, "fragment serializer fallback is correct");
+  assert.ok(!(store.serializerFor('name') instanceof Serializer), 'fragment serializer fallback is not `JSONAPISerializer`');
+  assert.ok(store.serializerFor('name') instanceof JSONSerializer, 'fragment serializer fallback is correct');
 });
 
-test("the default fragment serializer does not use the adapter's `defaultSerializer`", function(assert) {
+test('the default fragment serializer does not use the adapter\'s `defaultSerializer`', function(assert) {
   store.set('defaultAdapter.defaultSerializer', '-json-api');
 
-  assert.ok(!(store.serializerFor('name') instanceof JSONAPISerializer), "fragment serializer fallback is not `JSONAPISerializer`");
-  assert.ok(store.serializerFor('name') instanceof JSONSerializer, "fragment serializer fallback is correct");
+  assert.ok(!(store.serializerFor('name') instanceof JSONAPISerializer), 'fragment serializer fallback is not `JSONAPISerializer`');
+  assert.ok(store.serializerFor('name') instanceof JSONSerializer, 'fragment serializer fallback is correct');
 });
 
-test("the default fragment serializer is `serializer:-fragment` if registered", function(assert) {
-  var Serializer = JSONSerializer.extend();
+test('the default fragment serializer is `serializer:-fragment` if registered', function(assert) {
+  let Serializer = JSONSerializer.extend();
   owner.register('serializer:-fragment', Serializer);
 
-  assert.ok(store.serializerFor('name') instanceof Serializer, "fragment serializer fallback is correct");
+  assert.ok(store.serializerFor('name') instanceof Serializer, 'fragment serializer fallback is correct');
 });
 
-test("the application serializer can be looked up", function(assert) {
-  assert.ok(store.serializerFor('application') instanceof JSONSerializer, "application serializer can still be looked up");
+test('the application serializer can be looked up', function(assert) {
+  assert.ok(store.serializerFor('application') instanceof JSONSerializer, 'application serializer can still be looked up');
 });
 
-test("the default serializer can be looked up", function(assert) {
-  assert.ok(store.serializerFor('-default') instanceof JSONSerializer, "default serializer can still be looked up");
+test('the default serializer can be looked up', function(assert) {
+  assert.ok(store.serializerFor('-default') instanceof JSONSerializer, 'default serializer can still be looked up');
 });
 
-test("unloadAll destroys fragments", function(assert) {
+test('unloadAll destroys fragments', function(assert) {
   Ember.run(() => {
-    var person = store.createRecord('person', {
+    let person = store.createRecord('person', {
       name: {
-        first: "Catelyn",
-        last: "Stark"
+        first: 'Catelyn',
+        last: 'Stark'
       }
     });
-    var name = person.get('name');
+    let name = person.get('name');
 
     store.unloadAll();
 
-    Ember.run.schedule('destroy', function() {
-      assert.ok(person.get('isDestroying'), "the model is being destroyed");
-      assert.ok(name.get('isDestroying'), "the fragment is being destroyed");
+    Ember.run.schedule('destroy', () => {
+      assert.ok(person.get('isDestroying'), 'the model is being destroyed');
+      assert.ok(name.get('isDestroying'), 'the fragment is being destroyed');
     });
   });
 });


### PR DESCRIPTION
* [x] Function shorthand
* [x] Interpolated strings and single-quote.
  - Skipped the tests package because there were a LOT of double quote strings and I didn't want to make this review worse. 
* [x] const/let instead of var
* [x] spread arguments when calling `this._super()`
* [x] Fat arrow.
* [ ] ~ESLint~ _(Another PR later)_

I know this is a big PR to review. No rush, do it when you have time. I separated various topics into separate commits incase there was something we wanted to backout. My plan is to squash them all down into a single ES6 commit. Let me know what you think, happy to change anything add or remove stuff.

My motivation was to:
1. Get the code style more consistent (we had been writing ES6 stuff as new PRs were merged, but we still had a lot of ES5 stuff from the old'n days). 
2. Install ESLint and get a sane configuration (more on that to come in a future PR).