### PR TITLE
Fixing issue #245. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import {
   fragment,
   fragmentArray,
   array
-} from 'model-fragments/attributes';
+} from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   name      : fragment('name'),
@@ -72,7 +72,7 @@ export default Model.extend({
 ```javascript
 // app/models/name.js
 import attr from 'ember-data/attr';
-import Fragment from 'model-fragments/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
 
 export default Fragment.extend({
   first : attr('string'),
@@ -83,7 +83,7 @@ export default Fragment.extend({
 ```javascript
 // app/models/address.js
 import attr from 'ember-data/attr';
-import Fragment from 'model-fragments/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
 
 export default Fragment.extend({
   street  : attr('string'),
@@ -218,7 +218,7 @@ import {
   fragment,
   fragmentArray,
   array
-} from 'model-fragments/attributes';
+} from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   name      : fragment('name', { defaultValue: { first: 'Faceless', last: 'Man' } }),
@@ -244,7 +244,7 @@ Like `attr`, the `defaultValue` option can be a function that is invoked to gene
 ```javascript
 // app/models/person.js
 import Model from 'ember-data/model';
-import { fragment } from 'model-fragments/attributes';
+import { fragment } from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   name: fragment('name', {
@@ -264,7 +264,7 @@ Serializing records with fragment attributes works using a special `Transform` t
 ```javascript
 // app/models/name.js
 import attr from 'ember-data/attr';
-import Fragment from 'model-fragments/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
 
 export default Fragment.extend({
   given  : attr('string'),
@@ -353,7 +353,7 @@ Nesting of fragments is fully supported:
 // app/models/user.js
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import { fragmentArray } from 'model-fragments/attributes';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   name   : attr('string'),
@@ -364,8 +364,8 @@ export default Model.extend({
 ```javascript
 // app/models/order.js
 import attr from 'ember-data/attr';
-import Fragment from 'model-fragments/fragment';
-import { fragmentArray } from 'model-fragments/attributes';
+import Fragment from 'ember-data-model-fragments/fragment';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default Fragment.extend({
   amount   : attr('string'),
@@ -376,7 +376,7 @@ export default Fragment.extend({
 ```javascript
 // app/models/product.js
 import attr from 'ember-data/attr';
-import Fragment from 'model-fragments/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
 
 export default Fragment.extend({
   name  : attr('string'),
@@ -454,7 +454,7 @@ so to `typeKey`'s value can be `'animal'`, `'elephant'` or `'lion'`.
 // app/models/zoo.js
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import { fragmentArray } from 'model-fragments/attributes';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   name: attr('string'),
@@ -465,7 +465,7 @@ export default Model.extend({
 
 ```javascript
 // app/models/animal.js
-import Fragment from 'model-fragments/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
 import attr from 'ember-data/attr';
 
 App.Animal = Fragment.extend({

--- a/app/initializers/model-fragments.js
+++ b/app/initializers/model-fragments.js
@@ -1,9 +1,9 @@
 // Import the full module to ensure monkey-patchs are applied before any store
 // instances are created. Sad face for side-effects :(
-import 'model-fragments';
-import FragmentTransform from 'model-fragments/transforms/fragment';
-import FragmentArrayTransform from 'model-fragments/transforms/fragment-array';
-import ArrayTransform from 'model-fragments/transforms/array';
+import 'ember-data-model-fragments';
+import FragmentTransform from 'ember-data-model-fragments/transforms/fragment';
+import FragmentArrayTransform from 'ember-data-model-fragments/transforms/fragment-array';
+import ArrayTransform from 'ember-data-model-fragments/transforms/array';
 
 export default {
   name: 'fragmentTransform',

--- a/app/transforms/array.js
+++ b/app/transforms/array.js
@@ -1,2 +1,2 @@
-import ArrayTransform from 'model-fragments/transforms/array';
+import ArrayTransform from 'ember-data-model-fragments/transforms/array';
 export default ArrayTransform;

--- a/app/transforms/fragment-array.js
+++ b/app/transforms/fragment-array.js
@@ -1,2 +1,2 @@
-import FragmentArrayTransform from 'model-fragments/transforms/fragment-array';
+import FragmentArrayTransform from 'ember-data-model-fragments/transforms/fragment-array';
 export default FragmentArrayTransform;

--- a/app/transforms/fragment.js
+++ b/app/transforms/fragment.js
@@ -1,2 +1,2 @@
-import FragmentTransform from 'model-fragments/transforms/fragment';
+import FragmentTransform from 'ember-data-model-fragments/transforms/fragment';
 export default FragmentTransform;

--- a/blueprints/fragment/files/app/__path__/__name__.js
+++ b/blueprints/fragment/files/app/__path__/__name__.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 
 export default MF.Fragment.extend({
   <%= attrs %>

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var merge = require('broccoli-merge-trees');
 var version = require('./lib/version');
 
 module.exports = {
-  name: 'model-fragments',
+  name: 'ember-data-model-fragments',
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
@@ -21,6 +21,12 @@ module.exports = {
         this.ui.writeLine(message);
       }
     }
+  },
+
+  included: function() {
+    this._super.included.apply(this, arguments);
+
+    this.import('vendor/model-fragments-shim.js');
   },
 
   treeForAddon: function(tree) {

--- a/tests/dummy/app/models/address.js
+++ b/tests/dummy/app/models/address.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/animal.js
+++ b/tests/dummy/app/models/animal.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 
 export default MF.Fragment.extend({
   name: DS.attr('string')

--- a/tests/dummy/app/models/hobby.js
+++ b/tests/dummy/app/models/hobby.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/house.js
+++ b/tests/dummy/app/models/house.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/info.js
+++ b/tests/dummy/app/models/info.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/name.js
+++ b/tests/dummy/app/models/name.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/order.js
+++ b/tests/dummy/app/models/order.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/person.js
+++ b/tests/dummy/app/models/person.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 
 export default DS.Model.extend({
   title: DS.attr('string'),

--- a/tests/dummy/app/models/product.js
+++ b/tests/dummy/app/models/product.js
@@ -1,4 +1,4 @@
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 
 export default MF.Fragment.extend({

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 
 export default DS.Model.extend({
   info: MF.fragment('info'),

--- a/tests/dummy/app/models/zoo.js
+++ b/tests/dummy/app/models/zoo.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 
 export default DS.Model.extend({
   name: DS.attr('string'),

--- a/tests/integration/nested_test.js
+++ b/tests/integration/nested_test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';

--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';

--- a/tests/unit/array_property_test.js
+++ b/tests/unit/array_property_test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';

--- a/tests/unit/fragment_array_property_test.js
+++ b/tests/unit/fragment_array_property_test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';

--- a/tests/unit/fragment_owner_property_test.js
+++ b/tests/unit/fragment_owner_property_test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';

--- a/tests/unit/fragment_property_test.js
+++ b/tests/unit/fragment_property_test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import { test } from 'qunit';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';

--- a/tests/unit/model_fragments_module_test.js
+++ b/tests/unit/model_fragments_module_test.js
@@ -1,0 +1,34 @@
+import { test } from 'ember-qunit';
+import { module } from 'qunit';
+
+// Public modules / packages
+import MF from 'ember-data-model-fragments';
+import FragmentArray from 'ember-data-model-fragments/array/fragment';
+import StatefulArray from 'ember-data-model-fragments/array/stateful';
+import {
+  fragment, fragmentArray, array, fragmentOwner
+} from 'ember-data-model-fragments/attributes';
+import ArrayTransform from 'ember-data-model-fragments/transforms/array';
+import FragmentArrayTransform from 'ember-data-model-fragments/transforms/fragment-array';
+import FragmentTransform from 'ember-data-model-fragments/transforms/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
+import version from 'ember-data-model-fragments/version';
+
+module('model-fragments shim module');
+
+test('test the shim modules', function(assert) {
+  assert.expectDeprecation();
+
+  assert.equal(require('model-fragments')['default'], MF);
+  assert.equal(require('model-fragments/array/fragment')['default'], FragmentArray);
+  assert.equal(require('model-fragments/array/stateful')['default'], StatefulArray);
+  assert.equal(require('model-fragments/transforms/array')['default'], ArrayTransform);
+  assert.equal(require('model-fragments/transforms/fragment-array')['default'], FragmentArrayTransform);
+  assert.equal(require('model-fragments/transforms/fragment')['default'], FragmentTransform);
+  assert.equal(require('model-fragments/attributes')['fragment'], fragment);
+  assert.equal(require('model-fragments/attributes')['fragmentArray'], fragmentArray);
+  assert.equal(require('model-fragments/attributes')['array'], array);
+  assert.equal(require('model-fragments/attributes')['fragmentOwner'], fragmentOwner);
+  assert.equal(require('model-fragments/fragment')['default'], Fragment);
+  assert.equal(require('model-fragments/version')['default'], version);
+});

--- a/tests/unit/serialize_test.js
+++ b/tests/unit/serialize_test.js
@@ -4,7 +4,7 @@ import moduleForAcceptance from '../helpers/module-for-acceptance';
 import getOwner from '../helpers/get-owner';
 import JSONSerializer from 'ember-data/serializers/json';
 import Person from 'dummy/models/person';
-import MF from 'model-fragments';
+import MF from 'ember-data-model-fragments';
 import DS from 'ember-data';
 let store, owner;
 

--- a/vendor/model-fragments-shim.js
+++ b/vendor/model-fragments-shim.js
@@ -1,0 +1,35 @@
+
+(function() {
+  var importPaths = [
+    '',
+    'array/fragment',
+    'array/stateful',
+    'transforms/array',
+    'transforms/fragment',
+    'transforms/fragment-array',
+    'utils/instance-of-type',
+    'utils/map',
+    'attributes',
+    'ext',
+    'fragment',
+    'index',
+    'states',
+    'version',
+  ];
+
+  function shimModule(name) {
+    if (name) { name = '/' + name; }
+    define('model-fragments' + name, function() {
+      Ember.deprecate('Importing from the `model-fragments` module is deprecated. ' +
+        'Instead import from `ember-data-model-fragments`.', false, {
+        id: 'model-fragments-module-import',
+        until: '3.0.0'
+      });
+      return require('ember-data-model-fragments' + name);
+    });
+  }
+
+  for (var i = 0; i < importPaths.length; i++) {
+    shimModule(importPaths[i]);
+  }
+})();


### PR DESCRIPTION
Unfortunately this requires use to change the module name of this addon from `model-fragments` to `ember-data-model-fragments`. Added a vendor shim to provide backwards compatibility.

See: #245. 

Two outstanding questions:

1. Are there any other implications here? _I can't think of any, it should just work._
2. Should we deprecate using `model-fragments` right away or wait a while?