### PR TITLE
Fix for Max Call Stack Size Exceeded error when using multiple aliases

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -18,6 +18,8 @@ import FragmentArray from './array/fragment';
 const keys = Object.keys || Ember.keys;
 const create = Object.create || Ember.create;
 const getOwner = Ember.getOwner;
+const assign = Ember.assign;
+const typeOf = Ember.typeOf;
 
 let InternalModelPrototype = InternalModel.prototype;
 const internalModelExpectsModelName = InternalModelPrototype.hasOwnProperty('modelClass');
@@ -275,6 +277,34 @@ decorateMethod(InternalModelPrototype, 'adapterDidError', function adapterDidErr
       fragment._adapterDidError(error);
     }
   }
+});
+
+/**
+  Ember Data may return false positives when working with fragments,
+  since our changed keys may be Javascript objects, and equality
+  between normal Javascript objects cannot be tested with `===`.
+
+  @method _changedKeys
+  @private
+*/
+decorateMethod(InternalModelPrototype, '_changedKeys', function changedKeysFragments(changedKeys, args) {
+  let updates = args[0];
+  let original = assign({}, this._data);
+  original = assign(original, this._inFlightAttributes);
+
+  let i = 0;
+  while (i < changedKeys.length) {
+    let changedKey = changedKeys[i];
+    if (typeOf(original[changedKey]) === 'object' || typeOf(original[changedKey]) === 'array') {
+      if (JSON.stringify(original[changedKey]) === JSON.stringify(updates[changedKey])) {
+        changedKeys.splice(i, 1);
+        continue;
+      }
+    }
+    i += 1;
+  }
+
+  return changedKeys;
 });
 
 /**

--- a/addon/states.js
+++ b/addon/states.js
@@ -7,6 +7,7 @@ import RootState from 'ember-data/-private/system/model/states';
 
 const get = Ember.get;
 const create = Object.create || Ember.create;
+const assign = Ember.assign;
 
 const didSetProperty = RootState.loaded.saved.didSetProperty;
 const propertyWasReset = RootState.loaded.updated.uncommitted.propertyWasReset;
@@ -168,9 +169,9 @@ export default FragmentRootState;
 
 export function fragmentDidDirty(record, key, fragment) {
   if (!get(record, 'isDeleted')) {
-    // Add the fragment as a placeholder in the owner record's
+    // Add the fragment data as a placeholder in the owner record's
     // `_attributes` hash to indicate it is dirty
-    record._internalModel._attributes[key] = fragment;
+    record._internalModel._attributes[key] = fragment && assign({}, fragment._data, fragment._attributes);
 
     record.send('becomeDirty');
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "3.0.2",
     "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-pretender": "^1.0.1",
     "ember-cli-qunit": "^2.2.3",

--- a/tests/dummy/app/components/alias-component.js
+++ b/tests/dummy/app/components/alias-component.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  model: null,
+
+  firstAlias: Ember.computed.alias('model.passenger'),
+  secondAlias: Ember.computed.alias('firstAlias.name')
+});

--- a/tests/dummy/app/models/passenger.js
+++ b/tests/dummy/app/models/passenger.js
@@ -1,0 +1,5 @@
+import MF from 'ember-data-model-fragments';
+
+export default MF.Fragment.extend({
+  name: MF.fragment('name')
+});

--- a/tests/dummy/app/models/vehicle.js
+++ b/tests/dummy/app/models/vehicle.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import MF from 'ember-data-model-fragments';
+
+export default DS.Model.extend({
+  passenger: MF.fragment('passenger')
+});

--- a/tests/dummy/app/templates/components/alias-component.hbs
+++ b/tests/dummy/app/templates/components/alias-component.hbs
@@ -1,0 +1,1 @@
+{{secondAlias.first}}

--- a/tests/integration/components/alias-component-test.js
+++ b/tests/integration/components/alias-component-test.js
@@ -1,0 +1,69 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Pretender from 'pretender';
+let owner, store, server;
+
+moduleForComponent('alias-component', 'Integration | Component | alias component', {
+  integration: true,
+  beforeEach() {
+    owner = Ember.getOwner(this);
+    store = owner.lookup('service:store');
+    server = new Pretender();
+  },
+
+  afterEach() {
+    store = null;
+    owner = null;
+    server.shutdown();
+  }
+});
+
+test('the adapter can update fragments without infinite loops when CPs are aliased more than once', function(assert) {
+  let payloadBefore = {
+    vehicle: {
+      id: 1,
+      passenger: {
+        name: {
+          first: 'Donna',
+          last: 'Noble'
+        }
+      }
+    }
+  };
+
+  let payloadAfter = {
+    vehicle: {
+      id: 1,
+      passenger: {
+        name: {
+          first: 'Donna',
+          last: 'Doctor'
+        }
+      }
+    }
+  };
+
+  let done = assert.async();
+
+  Ember.run(() => {
+    server.get('/vehicles/:id', function() {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify(payloadBefore)];
+    });
+
+    store.findRecord('vehicle', 1).then(vehicle => {
+      this.setProperties({ vehicle });
+      this.render(hbs`{{alias-component model=vehicle}}`);
+
+      this.set('vehicle.passenger.name.last', 'Doctor');
+      server.put('/vehicles/:id', function() {
+        return [200, { 'Content-Type': 'application/json' }, JSON.stringify(payloadAfter)];
+      });
+
+      vehicle.save().then(() => {
+        assert.ok(true);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Possible fix for #190.

Borrowed from repo @DingoEatingFuzz wrote to illustrate the bug to write a failing test. The issue as far as we could tell seemed to result from infinite recursion from always generating false-positives when checking what keys changed. Since the model's `_attributes` assigned in `states.js` L173 was the fragment's `InternalModel`, the `isEqual` comparison to the Object returned from the server in Ember Data's `_changedKeys` method would always be false, and thus the key would endlessly be returned to be passed along to observers watching for a change ... which would cause them to call `setupData`, which would call `_changedKeys`, etc. The combination of assigning the updated data to `_attributes` and then filtering `_changedKeys` based on whether the returned attributes are actually equal (cheating, perhaps, in using `JSON.stringify`) seems to have resolved the problem.