### PR TITLE
Make sure fragments are properly cleaned up when a model is unloaded.

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -156,6 +156,7 @@ Model.reopen({
       fragment = internalModel._fragments[key];
       if (fragment) {
         fragment.destroy();
+        delete internalModel._fragments[key];
       }
     }
 
@@ -164,6 +165,7 @@ Model.reopen({
       fragment = internalModel._data[key];
       if (fragment instanceof Fragment || fragment instanceof FragmentArray) {
         fragment.destroy();
+        delete internalModel._data[key];
       }
     }
   }

--- a/tests/dummy/app/models/zoo.js
+++ b/tests/dummy/app/models/zoo.js
@@ -5,5 +5,6 @@ export default DS.Model.extend({
   name: DS.attr('string'),
   city: DS.attr('string'),
   star: MF.fragment('animal', { polymorphic: true, typeKey: '$type' }),
-  animals: MF.fragmentArray('animal', { polymorphic: true, typeKey: '$type' })
+  animals: MF.fragmentArray('animal', { polymorphic: true, typeKey: '$type' }),
+  manager: DS.belongsTo('person')
 });


### PR DESCRIPTION
Fixes #261.

Comment explains it all: https://github.com/lytics/ember-data-model-fragments/issues/261#issuecomment-299482222 . TL;DR; ember-data has a new lifecycle for `internalModel`s with a loaded relationship. We have to do a better job cleaning up. 