### PR TITLE
Add cacheKeyForTree

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 var merge = require('broccoli-merge-trees');
 var version = require('./lib/version');
+var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 module.exports = {
   name: 'ember-data-model-fragments',
@@ -33,5 +34,9 @@ module.exports = {
     var versioned = merge([ version(), tree ]);
 
     return this._super.treeForAddon.call(this, versioned);
+  },
+
+  cacheKeyForTree(treeType) {
+    return calculateCacheKeyForTree(treeType, this);
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "broccoli-file-creator": "^1.1.1",
     "broccoli-merge-trees": "^2.0.0",
+    "calculate-cache-key-for-tree": "^1.1.0",
     "ember-cli-babel": "^6.0.0",
     "exists-sync": "^0.0.4",
     "git-repo-info": "^1.4.1",


### PR DESCRIPTION
This implements the `cacheKeyForTree` as outlined in [this RFC](https://github.com/ember-cli/rfcs/blob/master/complete/0090-addon-tree-caching.md).

See [Ember Data#5110](https://github.com/emberjs/data/pull/5110) for a more detailed explanation.