### PR TITLE
Fix changedAttributes out of sync with hasDirtyAttributes

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -129,8 +129,20 @@ Model.reopen({
     keys(internalModel._fragments).forEach(name => {
       // An actual diff of the fragment or fragment array is outside the scope
       // of this method, so just indicate that there is a change instead
-      if (name in internalModel._attributes) {
+      let record = internalModel._fragments[name];
+      let dirty;
+      if (record instanceof FragmentArray) {
+        dirty = record.any(x => x.currentState.isDirty);
+      } else if (record instanceof Fragment) {
+        dirty = record.currentState.isDirty;
+      } else {
+        dirty = !!diffData[name];
+      }
+
+      if (dirty) {
         diffData[name] = true;
+      } else {
+        delete diffData[name];
       }
     });
 

--- a/tests/unit/fragment_test.js
+++ b/tests/unit/fragment_test.js
@@ -164,6 +164,40 @@ test('fragment properties that are set to null are indicated in the owner record
   });
 });
 
+test('changedAttributes should stay in sync with hasDirtyAttributes', function(assert) {
+  Ember.run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          name: {
+            first: 'Rob',
+            last: 'Stark'
+          }
+        }
+      }
+    });
+
+    return store.find('person', 1).then(function(person) {
+      // side effect for the observer to work
+      person.get('name.hasDirtyAttributes');
+
+      person.addObserver('name.hasDirtyAttributes', function() {
+        let dirty = person.get('name.hasDirtyAttributes');
+        let changed = person.changedAttributes();
+        assert.equal(dirty, 'name' in changed, 'changedAttributes should agree with hasDirtyAttributes');
+      });
+
+      // make dirty
+      person.set('name.first', 'Sansa');
+
+      // make clean again
+      person.set('name.first', 'Rob');
+    });
+  });
+});
+
 test('changes to attributes can be rolled back', function(assert) {
   Ember.run(() => {
     store.push({


### PR DESCRIPTION
If I check `changedAttributes()` inside an observer for `hasDirtyAttributes`, the two values don't agree. The `changedAttributes` will say the property is dirty while `hasDirtyAttributes` says it's not, or vice-versa.