### PR TITLE
Fixed some tests

### DIFF
--- a/tests/unit/array_property_test.js
+++ b/tests/unit/array_property_test.js
@@ -108,7 +108,7 @@ module('unit - `MF.array` property', function(hooks) {
         nickName: 'Barristan Selmy'
       });
 
-      assert.ok(person.get('titles.length'), 1, 'default value length is correct');
+      assert.equal(person.get('titles.length'), 1, 'default value length is correct');
       assert.equal(person.get('titles.firstObject'), 'Ser', 'default value is correct');
     });
   });
@@ -123,7 +123,7 @@ module('unit - `MF.array` property', function(hooks) {
         nickName: 'Oberyn Martell'
       });
 
-      assert.ok(person.get('titles.length'), 1, 'default value length is correct');
+      assert.equal(person.get('titles.length'), 1, 'default value length is correct');
       assert.equal(person.get('titles.firstObject'), 'Viper', 'default value is correct');
     });
   });
@@ -138,7 +138,7 @@ module('unit - `MF.array` property', function(hooks) {
         nickName: 'Oberyn Martell'
       });
 
-      assert.ok(person.get('titles.length'), 1, 'default value length is correct');
+      assert.equal(person.get('titles.length'), 2, 'default value length is correct');
       assert.equal(person.get('titles.firstObject'), 'Viper', 'default value is correct');
     });
   });


### PR DESCRIPTION
Was just going over my merged PR https://github.com/lytics/ember-data-model-fragments/pull/286 and realised one of my tests and 2 others already in the code were passing even though they shouldn't have been.

They were using `assert.ok` when they should have been `assert.equal`