### PR TITLE
Fix EDMF for use with >3.2

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -10,6 +10,7 @@ import {
 } from './fragment';
 import FragmentArray from './array/fragment';
 import { isPresent } from '@ember/utils';
+import { computed } from '@ember/object';
 
 function serializerForFragment(owner, normalizedModelName) {
   let serializer = owner.lookup(`serializer:${normalizedModelName}`);
@@ -195,6 +196,25 @@ Model.reopen({
       }
     }
   }
+});
+
+Model.reopenClass({
+  fields: computed(function() {
+    let map = new Map();
+
+    this.eachComputedProperty((name, meta) => {
+      if (meta.isFragment) {
+        map.set(name, 'fragment');
+      } else if (meta.isRelationship) {
+        map.set(name, meta.kind);
+      } else if (meta.isAttribute) {
+        map.set(name, 'attribute');
+      }
+    });
+
+    return map;
+  }).readOnly()
+
 });
 
 // Replace a method on an object with a new one that calls the original and then


### PR DESCRIPTION
The `getRecords` function inside Ember Data treats attributes
differently.

Where once the it would set each attribute on the internal model with
`options[]=` (triggering the setter/getter we install to properly
install EDMF) it now calls `InternalModel#setDirtyAttribute`.

The deciding factor for whether something is an `attribute` was based
off the `meta` set on the installed CP's.  We're instead telling the
`InternalModel#fields` function to properly recognize fragments as
`"fragments"` which bypasses the `setDirtyAttribute` call and instead
does the default behavior from before.

Reopening the Model in this way preserves the previous behavior.

I suspect, this will likely need a large refactor when RFC293 lands

https://github.com/igorT/rfcs/blob/17e8f97049452ae18d3b12ee23c4858a6d5e0bfd/text/0000-model-data.md

Luckily, I believe IgorT is already begun the work there with this spike
listed in the above RFC:

https://github.com/igorT/ember-data.model-fragments/tree/igor/model-data