### PR TITLE
Update README.md to mention Ember 3.5 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Use the following table to decide which version of this project to use with your
 | >= v2.11.x < v2.13.x | v2.11.x |
 | >= v2.14.x < v3.0.x | v2.14.x |
 | >= v3.0.x < v3.2.x | v3.0.x-beta.1 |
-| >= v3.2.x | v3.3.x |
+| >= v3.2.x < v3.4.x | v3.3.x |
+| >= v3.5.x | Not yet supported |
 
 #### Notes
 
@@ -38,6 +39,7 @@ Use the following table to decide which version of this project to use with your
 - Ember Data 2.14 changed `-private` import paths. See [#266](https://github.com/lytics/ember-data-model-fragments/issues/266).
 - Ember Data 3.0 changed `ContainerInstanceCache` import paths. See [e4749c10](https://github.com/lytics/ember-data-model-fragments/pull/287/commits/e4749c107610a6d0dd6032a58c66356e6064562a).
 - Ember Data 3.2 changed `InternalModel#fields`. See: [#310](https://github.com/lytics/ember-data-model-fragments/pull/310).
+- Ember Data 3.5 added `RecordData` interfaces. (https://github.com/emberjs/rfcs/pull/293) (https://github.com/emberjs/data/pull/5616)
 
 ## Installation
 


### PR DESCRIPTION
Probably a good idea before people start upgrading to Ember 3.5 thinking that EDMF will work with it based on what the readme currently says