### PR TITLE
Nested polymorphic fragments do not respect custom Serializers normalize

### DIFF
--- a/tests/dummy/app/models/lion.js
+++ b/tests/dummy/app/models/lion.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import Animal from 'dummy/models/animal';
+import MF from 'ember-data-model-fragments';
 
 export default Animal.extend({
-  hasManes: DS.attr('boolean')
+  hasManes: DS.attr('boolean'),
+  preys: MF.fragmentArray('prey', { polymorphic: true, typeKey: '$type' })
 });

--- a/tests/dummy/app/models/prey-giraffe.js
+++ b/tests/dummy/app/models/prey-giraffe.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import Prey from 'dummy/models/prey';
+
+export default Prey.extend({
+  neckLength: DS.attr('string')
+});

--- a/tests/dummy/app/models/prey-hog.js
+++ b/tests/dummy/app/models/prey-hog.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import Prey from 'dummy/models/prey';
+
+export default Prey.extend({
+  stripesColour: DS.attr('string')
+});

--- a/tests/dummy/app/models/prey.js
+++ b/tests/dummy/app/models/prey.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import MF from 'ember-data-model-fragments';
+
+export default MF.Fragment.extend({
+  kind: DS.attr('string')
+});

--- a/tests/dummy/app/serializers/animal.js
+++ b/tests/dummy/app/serializers/animal.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+export default DS.JSONSerializer.extend({
+  normalize(modelClass, resourceHash) {
+    let result = this._super(modelClass, resourceHash);
+    if (resourceHash._normalizeBackendTypeTo$Type) {
+      Object.assign(result.data.attributes, resourceHash, {
+        $type: `${resourceHash.backendType}`
+      });
+    }
+    return result;
+  }
+});

--- a/tests/dummy/app/serializers/prey.js
+++ b/tests/dummy/app/serializers/prey.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+export default DS.JSONSerializer.extend({
+  normalize(modelClass, resourceHash) {
+    let result = this._super(modelClass, resourceHash);
+    if (resourceHash._normalizeBackendTypeTo$Type) {
+      Object.assign(result.data.attributes, resourceHash, {
+        $type: `prey-${resourceHash.backendType}`
+      });
+    }
+    return result;
+  }
+});

--- a/tests/integration/nested_polymorphic_test.js
+++ b/tests/integration/nested_polymorphic_test.js
@@ -1,0 +1,177 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import Animal from 'dummy/models/animal';
+import Lion from 'dummy/models/lion';
+import PreyGiraffe from 'dummy/models/prey-giraffe';
+import PreyHog from 'dummy/models/prey-hog';
+import Pretender from 'pretender';
+
+let store, owner, server;
+
+module('integration - Nested Polymorphic fragments with custom type normalizer', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function(assert) {
+    owner = this.owner;
+    store = owner.lookup('service:store');
+    server = new Pretender();
+
+    assert.expectNoDeprecation();
+  });
+
+  hooks.afterEach(function() {
+    store = null;
+    owner = null;
+    server.shutdown();
+  });
+
+  test('when all levels types are normalized', function(assert) {
+    let data = {
+      id: 1,
+      name: 'Nested Zoo',
+      animals: [
+        {
+          _normalizeBackendTypeTo$Type: true,
+          backendType: 'lion',
+          name: 'Mittens',
+          hasManes: 'true',
+          preys: [
+            {
+              _normalizeBackendTypeTo$Type: true,
+              backendType: 'giraffe',
+              neckLength: 20
+            },
+            {
+              _normalizeBackendTypeTo$Type: true,
+              backendType: 'hog',
+              stripesColour: 'golden'
+            }
+          ]
+        }
+      ]
+    };
+
+    server.get('/zoos/1', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ zoo: data })];
+    });
+
+    return store.find('zoo', 1).then(zoo => {
+      let animals = zoo.get('animals');
+      assert.equal(animals.get('length'), 1);
+
+      let first = animals.objectAt(0);
+      assert.ok(first instanceof Animal, 'first animal is Animal');
+      assert.equal(first.get('name'), 'Mittens', 'lion has correct name');
+      assert.ok(first instanceof Lion, 'first animal is Lion');
+      let lionPreys = first.get('preys');
+      assert.equal(lionPreys.get('length'), 2, 'lion has 2 preys');
+
+      let firstPrey = lionPreys.objectAt(0);
+      assert.ok(firstPrey instanceof PreyGiraffe, 'first prey is Giraffe');
+      assert.equal(firstPrey.get('neckLength'), '20', 'giraffe\'s neck length is correct');
+
+      let secondPrey = lionPreys.objectAt(1);
+      assert.ok(secondPrey instanceof PreyHog, 'second prey is Hog');
+      assert.equal(secondPrey.get('stripesColour'), 'golden', 'hog\'s stripes colour is correct');
+    });
+  });
+
+  test('when only inner level types are normalized', function(assert) {
+    let data = {
+      id: 1,
+      name: 'Nested Zoo',
+      animals: [
+        {
+          $type: 'lion',
+          name: 'Mittens',
+          hasManes: 'true',
+          preys: [
+            {
+              _normalizeBackendTypeTo$Type: true,
+              backendType: 'giraffe',
+              neckLength: 20
+            },
+            {
+              _normalizeBackendTypeTo$Type: true,
+              backendType: 'hog',
+              stripesColour: 'golden'
+            }
+          ]
+        }
+      ]
+    };
+
+    server.get('/zoos/1', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ zoo: data })];
+    });
+
+    return store.find('zoo', 1).then(zoo => {
+      let animals = zoo.get('animals');
+      assert.equal(animals.get('length'), 1);
+
+      let first = animals.objectAt(0);
+      assert.ok(first instanceof Animal, 'first animal is Animal');
+      assert.equal(first.get('name'), 'Mittens', 'lion has correct name');
+      assert.ok(first instanceof Lion, 'first animal is Lion');
+      let lionPreys = first.get('preys');
+      assert.equal(lionPreys.get('length'), 2, 'lion has 2 preys');
+
+      let firstPrey = lionPreys.objectAt(0);
+      assert.ok(firstPrey instanceof PreyGiraffe, 'first prey is Giraffe');
+      assert.equal(firstPrey.get('neckLength'), '20', 'giraffe\'s neck length is correct');
+
+      let secondPrey = lionPreys.objectAt(1);
+      assert.ok(secondPrey instanceof PreyHog, 'second prey is Hog');
+      assert.equal(secondPrey.get('stripesColour'), 'golden', 'hog\'s stripes colour is correct');
+    });
+  });
+
+  test('when only outer level types are normalized', function(assert) {
+    let data = {
+      id: 1,
+      name: 'Nested Zoo',
+      animals: [
+        {
+          _normalizeBackendTypeTo$Type: true,
+          backendType: 'lion',
+          name: 'Mittens',
+          hasManes: 'true',
+          preys: [
+            {
+              $type: 'prey-giraffe',
+              neckLength: 20
+            },
+            {
+              $type: 'prey-hog',
+              stripesColour: 'golden'
+            }
+          ]
+        }
+      ]
+    };
+
+    server.get('/zoos/1', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ zoo: data })];
+    });
+
+    return store.find('zoo', 1).then(zoo => {
+      let animals = zoo.get('animals');
+      assert.equal(animals.get('length'), 1);
+
+      let first = animals.objectAt(0);
+      assert.ok(first instanceof Animal, 'first animal is Animal');
+      assert.equal(first.get('name'), 'Mittens', 'lion has correct name');
+      assert.ok(first instanceof Lion, 'first animal is Lion');
+      let lionPreys = first.get('preys');
+      assert.equal(lionPreys.get('length'), 2, 'lion has 2 preys');
+
+      let firstPrey = lionPreys.objectAt(0);
+      assert.ok(firstPrey instanceof PreyGiraffe, 'first prey is Giraffe');
+      assert.equal(firstPrey.get('neckLength'), '20', 'giraffe\'s neck length is correct');
+
+      let secondPrey = lionPreys.objectAt(1);
+      assert.ok(secondPrey instanceof PreyHog, 'second prey is Hog');
+      assert.equal(secondPrey.get('stripesColour'), 'golden', 'hog\'s stripes colour is correct');
+    });
+  });
+});

--- a/tests/integration/nested_polymorphic_test.js
+++ b/tests/integration/nested_polymorphic_test.js
@@ -25,7 +25,7 @@ module('integration - Nested Polymorphic fragments with custom type normalizer',
     server.shutdown();
   });
 
-  test('when all levels types are normalized', function(assert) {
+  test('when outter array is normalized and inner array is normalized', function(assert) {
     let data = {
       id: 1,
       name: 'Nested Zoo',
@@ -76,7 +76,7 @@ module('integration - Nested Polymorphic fragments with custom type normalizer',
     });
   });
 
-  test('when only inner level types are normalized', function(assert) {
+  test('when outter array has $type and inner array is normalized', function(assert) {
     let data = {
       id: 1,
       name: 'Nested Zoo',
@@ -126,7 +126,7 @@ module('integration - Nested Polymorphic fragments with custom type normalizer',
     });
   });
 
-  test('when only outer level types are normalized', function(assert) {
+  test('when outter array is normalized and inner array has $type', function(assert) {
     let data = {
       id: 1,
       name: 'Nested Zoo',


### PR DESCRIPTION
**Problem:**
In our applications we use polymorphic fragment models. Our application structure is complex, and hence our model types looks like `common/blocks/text`, which is specific to our ember application and different from the API. We want to keep the server API clean and persist types like `text`.

We found out that we can use custom ember `Serializer` with overriden `normalize` method, that can add inferred ember model type from the type in the payload. For example:

```
normalize(modelClass, resourceHash) {
    let result = this._super(modelClass, resourceHash);
    
    Object.assign(result.data.attributes, resourceHash, {
      $type: `common/blocks/${resourceHash.type}`
    });

    return result;
  }
```

This works perfectly when we have only flat structure of polymorphic models.

However it brakes when we expand the structure to be nested. For example we want to have polymorphic array of `common/content`, and then one of them, for example `common/content/with-block` includes another polymorphic array of `common/block`:

```js
// common/content/with-block model
blocks: MF.fragmentArray('common/block', { polymorphic: true, typeKey: '$type' })

// content-container model
contents: MF.fragmentArray('common/content', { polymorphic: true, typeKey: '$type' })
```

In this branch I've simulated the use case in the test cases, so we can discuss whether or not this is supposed to be supported by this package and how :)
