### PR TITLE
Fix for passing fragment arrays to fragments

### DIFF
--- a/addon/array/fragment.js
+++ b/addon/array/fragment.js
@@ -27,7 +27,7 @@ function normalizeFragmentArray(array, content, objs, canonical) {
 
   return objs.map((data, index) => {
     let type = get(array, 'type');
-    assert(`You can only add '${type}' fragments or object literals to this property`, typeOf(data) === 'object' || isInstanceOfType(store.modelFor(type), data));
+    assert(`You can only add '${type}' fragments or object literals to the '${key}' property`, typeOf(data) === 'object' || isInstanceOfType(store.modelFor(type), data));
 
     if (isFragment(data)) {
       fragment = data;
@@ -259,7 +259,8 @@ const FragmentArray = StatefulArray.extend({
     this._originalState.forEach(fragment => {
       fragment.destroy();
     });
-  }
+  },
+  _isFragmentArray: true
 });
 
 export default FragmentArray;

--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -69,7 +69,7 @@ const StatefulArray = ArrayProxy.extend(Copyable, {
 
     this._pendingData = data;
 
-    let processedData = this._normalizeData(makeArray(data));
+    let processedData = this._normalizeData(data._isFragmentArray ? copy(data) : makeArray(data));
     let content = get(this, 'content');
 
     // This data is canonical, so create rollback point

--- a/tests/unit/fragment_array_test.js
+++ b/tests/unit/fragment_array_test.js
@@ -116,6 +116,37 @@ module('unit - `MF.fragmentArray`', function(hooks) {
     });
   });
 
+  test('fragment arrays can be added to fragments', function(assert) {
+    let order = store.createFragment('order', {
+      amount: '799.98',
+      products: [
+        {
+          name: 'Tears of Lys',
+          sku: 'poison-bd-32',
+          price: '499.99'
+        },
+        {
+          name: 'The Strangler',
+          sku: 'poison-md-24',
+          price: '299.99'
+        }
+      ]
+    });
+    let user = store.createRecord('user', {
+      info: {
+        name: 'Tyrion Lannister',
+        notes: ['smart', 'short']
+      },
+      orders: [
+        {
+          amount: '799.98',
+          products: order.products
+        }
+      ]
+    });
+    assert.equal(user.orders.firstObject.products.firstObject.name, 'Tears of Lys', 'No problems');
+  });
+
   test('fragments can be removed from the fragment array', function(assert) {
     run(() => {
       store.push({

--- a/tests/unit/fragment_array_test.js
+++ b/tests/unit/fragment_array_test.js
@@ -145,6 +145,10 @@ module('unit - `MF.fragmentArray`', function(hooks) {
       ]
     });
     assert.equal(user.orders.firstObject.products.firstObject.name, 'Tears of Lys', 'No problems');
+
+    order.products.firstObject.set('name', 'Wolfsbane');
+    assert.equal(order.products.firstObject.name, 'Wolfsbane', 'Modifies the original fragment array');
+    assert.equal(user.orders.firstObject.products.firstObject.name, 'Tears of Lys', 'It does not modify the passed fragment array');
   });
 
   test('fragments can be removed from the fragment array', function(assert) {


### PR DESCRIPTION
Bringing this PR over from https://github.com/richgt/ember-data.model-fragments/pull/1 as I can't redirect the PR to a different repo.

@richgt @igorT This is a potential patch fix for the issue [I mentioned](https://github.com/lytics/ember-data-model-fragments/pull/360/#issuecomment-633257505) I've been encountering with the `RecordData` refactor.

## The use case
I previously mentioned:
> Model Fragments doesn't provide an API to create Fragment Arrays (see issue https://github.com/lytics/ember-data-model-fragments/issues/272) so a workaround we use in our app in cases where we want to set a fragmentArray (and possibly what Factory Guy also does) is to create a fragment using `store.createFragment` with a fragment array on it. We'll then take that fragment array property value and pass it to a `store.createRecord` call elsewhere. This is an extremely simplified case below.

> ```js
> let parentClone = store.createFragment('parent', {
>  children: [{
>    name: 'Pat'
>  }]
>});
>let grandparent = store.createRecord('grandparent', {
>  parent: {
>    children: parentClone.children,
>  }
>});
>```

This issue is also causing us a lot of problems in how we bootstrap our tests as we use Factory Guy quite heavily. We'll do something like the following a lot where `make` will create our models and model fragments for us. In the following example `grandparent.parent.children` is a fragment array.

```js
test('grandparent works with factory guy', function(assert) {
    let grandparent = make('grandparent', {
      parent: make('parent'),
    });
    assert.equal(grandparent.parent.children.firstObject.name, 'Pat', 'Name is Pat');
  });
```

## The problem
The specific problem appears to be that in current master when pass the `children` fragment array to the new model it doesn't try and normalize the fragment array a second time, but in the refactor it does. The error it throws is the following if you try to pass a fragmentArray to another model.

```
Error: Assertion Failed: You can only add 'child' fragments or object literals to this property
    at Object.assert (http://localhost:58354/assets/vendor.js:36148:15)
    at http://localhost:58354/assets/vendor.js:98132:120
    at Array.map (<anonymous>)
    at normalizeFragmentArray (http://localhost:58354/assets/vendor.js:98130:17)
    at Class._normalizeData (http://localhost:58354/assets/vendor.js:98192:14)
    at Class.setupData (http://localhost:58354/assets/vendor.js:98426:32)
    at FragmentRecordData.setupFragmentArray (http://localhost:58354/assets/vendor.js:99634:23)
    at FragmentRecordData.getFragmentArray (http://localhost:58354/assets/vendor.js:99608:30)
    at Parent.get (http://localhost:58354/assets/vendor.js:98722:48)
    at http://localhost:58354/assets/vendor.js:15522:32
```

It seems that when we are getting to this [line](https://github.com/richgt/ember-data.model-fragments/blob/f7810c9a2bfbe86aa665b3e488048be65c8101f2/addon/array/fragment.js#L30)
```js
typeOf(data) === 'object' || isInstanceOfType(store.modelFor(type), data)
```
when trying to set up the FragmentArray, the `instance of` check in `normalizeFragmentArray` assertion is throwing. This is even though we are trying to add the correct type of fragment to the fragment array.

## The fix
Digging in the actual problem is that rather than passing the Fragment Array directly to `normalizeFragmentArray` we are actually passing a Fragment Array wrapped in another array. This is due to the following line https://github.com/richgt/ember-data.model-fragments/blob/ab24b0fbd4870ac129ed634eb82181758b86524c/addon/array/stateful.js#L72. We aren't checking whether the passed `data` is already an array and are always wrapping it in one. My naive patch is to detect whether it's a fragment array and then copy it.